### PR TITLE
fix(deploy): Add healthcheck to postgres service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,8 @@ services:
       - .:/app
       - ./.env:/app/.env
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 
   postgres:
     image: pgvector/pgvector:pg16
@@ -50,6 +51,11 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-podcast_rag_db}
       - POSTGRES_USER=${POSTGRES_USER:-podcast_rag_user}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-insecure_password_change_me}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-podcast_rag_user} -d ${POSTGRES_DB:-podcast_rag_db}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 volumes:
   postgres_data: 


### PR DESCRIPTION
Adds a healthcheck to the `postgres` service in `docker-compose.yml` to ensure the database is fully ready before other services attempt to connect.

This resolves a race condition where the `db-init` service would try to run before the PostgreSQL server was available, causing an error on startup. The `db-init` service now waits for the `postgres` service to be healthy.