### PR TITLE
fix(deps): Add missing postgres and pgvector libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ httpx
 boto3
 tqdm
 python-dateutil
+psycopg2-binary
+pgvector


### PR DESCRIPTION
Adds `psycopg2-binary` and `pgvector` to `requirements.txt`.

These libraries are essential for the application to connect to the PostgreSQL database and handle the vector data type. Their absence was causing the `db-init` service to fail immediately upon startup due to an import error.