### PR TITLE
fix(deploy): Remove .env volume mount from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       - "8080:8080"
     volumes:
       - .:/app
-      - ./.env:/app/.env
     depends_on:
       db-init:
         condition: service_completed_successfully
@@ -16,7 +15,6 @@ services:
     command: python src/podcast_download_service.py
     volumes:
       - .:/app
-      - ./.env:/app/.env
     depends_on:
       db-init:
         condition: service_completed_successfully
@@ -26,7 +24,6 @@ services:
     command: python src/transcription_service.py
     volumes:
       - .:/app
-      - ./.env:/app/.env
     depends_on:
       db-init:
         condition: service_completed_successfully
@@ -36,7 +33,6 @@ services:
     command: python scripts/init_db.py --yes
     volumes:
       - .:/app
-      - ./.env:/app/.env
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Removes the direct mounting of the `.env` file as a volume from all services in `docker-compose.yml`.

This prevents a conflict where the repository's `.env` file would overwrite the environment variables injected by the deployment environment (e.g., Dokploy), causing the application to fail with incorrect configuration.

The application now correctly relies on the runtime environment for its configuration, which is the standard for containerized deployments.