### PR TITLE
fix(docker): Remove cache file copy from Dockerfile.web

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -41,8 +41,9 @@ COPY --chown=podcast:podcast src/ ./src/
 COPY --chown=podcast:podcast prompts/ ./prompts/
 COPY --chown=podcast:podcast pyproject.toml ./
 
-# Copy File Search cache (baked into image for fast startup)
-COPY --chown=podcast:podcast .file_search_cache.json ./.file_search_cache.json
+# Note: .file_search_cache.json is NOT included in the image
+# The web app will use a shared cache volume in homelab deployments
+# or build the cache on first query if not available
 
 # Install the project itself
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/


### PR DESCRIPTION
## Summary
- Removes `.file_search_cache.json` COPY from Dockerfile.web since the file is not in the repository
- Web app handles missing cache gracefully by returning empty metadata for citations
- Cache should be shared via volume mount in homelab deployments

## Fixes
- Docker build failure: `"/.file_search_cache.json": not found`

## Test plan
- [ ] Docker build completes successfully
- [ ] Web app starts without cache file
- [ ] Citations display (with empty metadata if no cache)