### PR TITLE
fix(email): improve deliverability with domain-matched links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,9 +19,16 @@ GEMINI_FILE_SEARCH_STORE_NAME=podcast-transcripts
 # Get your API key from: https://resend.com/api-keys
 RESEND_API_KEY=
 # Email address to send from (must be verified in Resend)
-RESEND_FROM_EMAIL=noreply@podcasts.hutchison.org
+# Note: Avoid using "no-reply" as it decreases inbox trust
+RESEND_FROM_EMAIL=podcast@podcasts.hutchison.org
 # Display name for sender
 RESEND_FROM_NAME="Podcast RAG"
+
+# --- Web App Base URL (for email links) ---
+# Base URL for the web application (used in email links)
+# This should match your sending domain to avoid spam filters
+# Example: https://podcasts.hutchison.org
+WEB_BASE_URL=
 
 # --- Email Digest Settings ---
 # Hour of day (0-23) to send daily digest emails

--- a/src/config.py
+++ b/src/config.py
@@ -75,8 +75,11 @@ class Config:
 
         # Email configuration (Resend)
         self.RESEND_API_KEY = os.getenv("RESEND_API_KEY", "")
-        self.RESEND_FROM_EMAIL = os.getenv("RESEND_FROM_EMAIL", "noreply@podcasts.hutchison.org")
+        self.RESEND_FROM_EMAIL = os.getenv("RESEND_FROM_EMAIL", "podcast@podcasts.hutchison.org")
         self.RESEND_FROM_NAME = os.getenv("RESEND_FROM_NAME", "Podcast RAG")
+
+        # Web app base URL for email links (ensures links match sending domain)
+        self.WEB_BASE_URL = os.getenv("WEB_BASE_URL", "")
 
         # Email digest settings
         self.EMAIL_DIGEST_SEND_HOUR = int(os.getenv("EMAIL_DIGEST_SEND_HOUR", "8"))  # 8 AM


### PR DESCRIPTION
## Summary
- Change default from email from `noreply@` to `podcast@` to increase inbox trust (Resend recommendation)
- Add `WEB_BASE_URL` config option to generate episode page links that match the sending domain
- Update email digest renderer to link to episode pages instead of external audio URLs

These changes address Resend's deliverability feedback to reduce spam filter triggers.

## Configuration
To enable domain-matched links, set `WEB_BASE_URL` in your `.env`:
```
WEB_BASE_URL=https://podcasts.hutchison.org
```

If not configured, links fall back to the podcast's audio file URL.

## Test plan
- [x] All existing tests pass (439 passed)
- [x] Verified `build_episode_url()` generates correct URLs with `WEB_BASE_URL` set
- [x] Verified fallback behavior when `WEB_BASE_URL` is not configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable WEB_BASE_URL setting for episode links in email communications
  * Added EMAIL_DIGEST_TIMEZONE configuration option (defaults to America/Los_Angeles)

* **Bug Fixes**
  * Changed sender email address from no-reply to podcast@podcasts.hutchison.org to improve email deliverability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->