### PR TITLE
fix(db): add pool_recycle to prevent stale connection errors

### DIFF
--- a/src/db/factory.py
+++ b/src/db/factory.py
@@ -24,6 +24,7 @@ def create_repository(
     echo: bool = False,
     create_tables: bool = False,
     pool_pre_ping: bool = True,  # Detect stale connections
+    pool_recycle: int = 1800,  # Recycle connections after 30 minutes
 ) -> PodcastRepositoryInterface:
     """
     Create a PodcastRepositoryInterface configured from the provided or discovered database URL.
@@ -38,6 +39,7 @@ def create_repository(
         create_tables (bool): If true, create database tables directly (for testing only;
             production should use Alembic migrations).
         pool_pre_ping (bool): Test connections for liveness before using (recommended for Supabase).
+        pool_recycle (int): Seconds after which to recycle connections (default 1800 = 30 minutes).
 
     Returns:
         PodcastRepositoryInterface: A repository instance backed by the resolved database URL.
@@ -71,6 +73,7 @@ def create_repository(
         max_overflow=max_overflow,
         echo=echo,
         pool_pre_ping=pool_pre_ping,
+        pool_recycle=pool_recycle,
     )
 
     # Create tables directly for testing (production should use Alembic migrations)

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -1089,6 +1089,7 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
         max_overflow: int = 2,  # Supabase-optimized
         echo: bool = False,
         pool_pre_ping: bool = True,  # Detect stale connections
+        pool_recycle: int = 1800,  # Recycle connections after 30 minutes
     ):
         """
         Initialize the repository and configure its SQLAlchemy engine and session factory.
@@ -1101,6 +1102,7 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
             max_overflow (int): Maximum overflow connections for non-SQLite databases (default 2 for Supabase).
             echo (bool): If true, enable SQLAlchemy SQL statement logging.
             pool_pre_ping (bool): If true, test connections for liveness before using them (recommended for Supabase).
+            pool_recycle (int): Seconds after which to recycle connections (default 1800 = 30 minutes).
         """
         self.database_url = database_url
 
@@ -1118,6 +1120,7 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
                 pool_size=pool_size,
                 max_overflow=max_overflow,
                 pool_pre_ping=pool_pre_ping,  # Test connections before use
+                pool_recycle=pool_recycle,  # Proactively recycle stale connections
                 echo=echo,
             )
 


### PR DESCRIPTION
## Summary

- Add `pool_recycle=1800` (30 minutes) to SQLAlchemy engine configuration
- Proactively recycles database connections before they go stale
- Fixes overnight pipeline crashes caused by PostgreSQL/Supabase closing idle connections

## Problem

The pipeline crashed overnight with:
```
psycopg2.OperationalError: server closed the connection unexpectedly
```

The connection was idle for ~2 hours between 23:28 and 01:32, and the database server closed it. When the pipeline tried to use the stale connection, it failed.

## Solution

Added `pool_recycle=1800` to the SQLAlchemy engine, which instructs the connection pool to close and recreate connections older than 30 minutes. Combined with the existing `pool_pre_ping=True`, this provides robust protection:

1. **pool_recycle**: Proactively closes connections older than 30 minutes
2. **pool_pre_ping**: Tests connections before use as a backup safety net

## Test plan

- [x] All 459 tests pass
- [ ] Run pipeline overnight to verify no connection errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database connection recycling is now configurable, defaulting to 30-minute intervals for improved connection stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->