### PR TITLE
fix(schema): loosen StoryItem constraints for Gemini

### DIFF
--- a/src/schemas.py
+++ b/src/schemas.py
@@ -9,11 +9,11 @@ class StoryItem(BaseModel):
 
     headline: str = Field(
         description="Brief headline (5-10 words)",
-        max_length=100
+        max_length=150  # Lenient: Gemini doesn't always respect constraints
     )
     summary: str = Field(
         description="One sentence summary of the story",
-        max_length=200
+        max_length=400  # Lenient: Gemini doesn't always respect constraints
     )
 
 


### PR DESCRIPTION
## Summary
- Loosen `StoryItem` Pydantic constraints for Gemini structured output
  - `headline`: max 100 → 150
  - `summary`: max 200 → 400

Gemini's structured output doesn't reliably respect max_length constraints. This caused validation failures for news podcast story summaries.

## Context
Follow-up to commits b71f21e and 272bdc9 which loosened other schema constraints. This fixes the remaining constraint issue found during backfill of news podcasts.

## Test plan
- [x] Tested backfill script on "Up First from NPR" episode with news stories
- [x] All 6 episodes from last 24 hours now have ai_email_content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended character limits for story submissions: headlines can now be up to 150 characters (previously 100) and summaries up to 400 characters (previously 200), allowing for more detailed and comprehensive content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->