### PR TITLE
fix(post_processor): pass email_content to mark_metadata_complete

### DIFF
--- a/src/workflow/post_processor.py
+++ b/src/workflow/post_processor.py
@@ -290,6 +290,7 @@ class PostProcessor:
                 guests=merged.guests,
                 mp3_artist=merged.mp3_artist,
                 mp3_album=merged.mp3_album,
+                email_content=merged.email_content,
             )
 
             self._stats.increment_metadata_processed()


### PR DESCRIPTION
## Summary
- Fixed bug where `email_content` was not being passed to `mark_metadata_complete` in the PostProcessor
- This caused all episodes processed through the async pipeline to have `NULL` `ai_email_content` even though extraction was successful

## Root Cause
The `_process_metadata` method in `PostProcessor` was calling `mark_metadata_complete` with all metadata fields except `email_content`. The MetadataWorker correctly extracts `email_content` from the merged result, but it wasn't being persisted.

## Test plan
- [ ] Deploy and run pipeline on new episodes
- [ ] Verify `ai_email_content` is populated for newly processed episodes
- [ ] Run backfill script for episodes missing email content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email content is now captured and included in episode metadata storage during post-processing, ensuring comprehensive episode information is preserved for archival and reference purposes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->