### PR TITLE
feat(deploy): VPS migration runbook + scripts (homelab compose layout)

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -73,4 +73,10 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 # Start web server
-CMD ["uvicorn", "src.web.app:app", "--host", "0.0.0.0", "--port", "8080"]
+# --proxy-headers + --forwarded-allow-ips=* make uvicorn trust the
+# X-Forwarded-Proto/For headers set by the upstream proxy (Cloudflare
+# Tunnel / cloudflared, or Cloud Run). Without this the app would build
+# http:// OAuth redirect URIs, mishandle Secure cookies, and see every
+# request as coming from the proxy's IP for rate limiting.
+CMD ["uvicorn", "src.web.app:app", "--host", "0.0.0.0", "--port", "8080", \
+     "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -84,7 +84,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 # to supply those headers. Default '*' keeps the image working on Cloud
 # Run (where the upstream IP is dynamic) and behind any reverse proxy on
 # an isolated network. Override at deploy time with a tighter allowlist
-# when the proxy IP/CIDR is known — see docker-compose.yml.
+# when the proxy IP/CIDR is known — see docs/deploy-vps.md.
 ENV UVICORN_FORWARDED_ALLOW_IPS=*
 
 CMD ["uvicorn", "src.web.app:app", "--host", "0.0.0.0", "--port", "8080", \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -72,11 +72,20 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
 # Entrypoint wraps CMD with doppler when DOPPLER_TOKEN is set
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# Start web server
-# --proxy-headers + --forwarded-allow-ips=* make uvicorn trust the
-# X-Forwarded-Proto/For headers set by the upstream proxy (Cloudflare
-# Tunnel / cloudflared, or Cloud Run). Without this the app would build
-# http:// OAuth redirect URIs, mishandle Secure cookies, and see every
-# request as coming from the proxy's IP for rate limiting.
+# Start web server.
+#
+# --proxy-headers makes uvicorn use X-Forwarded-Proto/For from the upstream
+# proxy (Cloudflare Tunnel / cloudflared, or Cloud Run); without it OAuth
+# would build http:// redirect URIs, Secure cookies would misbehave, and
+# rate limiting would see every request as coming from the proxy's IP.
+#
+# UVICORN_FORWARDED_ALLOW_IPS is uvicorn's env-var form of
+# --forwarded-allow-ips and controls which connecting-peer IPs are trusted
+# to supply those headers. Default '*' keeps the image working on Cloud
+# Run (where the upstream IP is dynamic) and behind any reverse proxy on
+# an isolated network. Override at deploy time with a tighter allowlist
+# when the proxy IP/CIDR is known — see docker-compose.yml.
+ENV UVICORN_FORWARDED_ALLOW_IPS=*
+
 CMD ["uvicorn", "src.web.app:app", "--host", "0.0.0.0", "--port", "8080", \
-     "--proxy-headers", "--forwarded-allow-ips", "*"]
+     "--proxy-headers"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,56 @@
 version: '3.8'
 
 services:
+  # Local PostgreSQL — replaces the Supabase-hosted database.
+  podcast-rag-db:
+    image: postgres:17
+    container_name: podcast-rag-db
+    restart: unless-stopped
+
+    environment:
+      POSTGRES_USER: podcast_rag
+      POSTGRES_DB: podcast_rag
+      # Substituted from the environment at "docker compose up" time.
+      # Run:  doppler run -- docker compose up -d   (or set it in .env).
+      POSTGRES_PASSWORD: "${LOCAL_DB_PASSWORD}"
+
+    # Published to localhost only, for host-side admin tooling (alembic,
+    # psql, verification scripts). App containers reach the DB over
+    # podcast-rag-net by the service name, not this port.
+    ports:
+      - "127.0.0.1:5432:5432"
+
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+    networks:
+      - podcast-rag-net
+
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U podcast_rag -d podcast_rag"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   podcast-rag:
     image: allenhutchison/podcast-rag:latest
     container_name: podcast-rag
     restart: unless-stopped
+
+    # Start only once the local database is accepting connections
+    depends_on:
+      podcast-rag-db:
+        condition: service_healthy
+
+    networks:
+      - podcast-rag-net
 
     # Environment variables
     env_file:
@@ -51,9 +97,18 @@ services:
     container_name: podcast-rag-web
     restart: unless-stopped
 
-    # Port mapping
+    # Start only once the local database is accepting connections
+    depends_on:
+      podcast-rag-db:
+        condition: service_healthy
+
+    networks:
+      - podcast-rag-net
+
+    # Port mapping — localhost only. Public traffic arrives via the
+    # cloudflared service, which reaches this container over podcast-rag-net.
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
 
     # Environment variables
     env_file:
@@ -102,6 +157,9 @@ services:
     profiles:
       - manual  # Only start manually with --profile manual
 
+    networks:
+      - podcast-rag-net
+
     env_file:
       - .env
     environment:
@@ -119,3 +177,41 @@ services:
       options:
         max-size: "5m"
         max-file: "2"
+
+  # Cloudflare Tunnel — terminates TLS at Cloudflare's edge and forwards
+  # public traffic to podcast-rag-web. Outbound-only: no inbound ports.
+  # Ingress rules (hostname -> http://podcast-rag-web:8080) are managed
+  # in the Cloudflare Zero Trust dashboard for this token's tunnel.
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: podcast-rag-cloudflared
+    restart: unless-stopped
+
+    command: tunnel --no-autoupdate run
+
+    environment:
+      # Substituted from the environment at "docker compose up" time.
+      # Run:  doppler run -- docker compose up -d   (or set it in .env).
+      TUNNEL_TOKEN: "${CLOUDFLARE_TUNNEL_TOKEN}"
+
+    depends_on:
+      - podcast-rag-web
+
+    networks:
+      - podcast-rag-net
+
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+volumes:
+  # Persistent storage for the local PostgreSQL data directory
+  pgdata:
+    driver: local
+
+networks:
+  # Internal network shared by the database, pipeline, web, and tunnel
+  podcast-rag-net:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,56 +1,10 @@
 version: '3.8'
 
 services:
-  # Local PostgreSQL — replaces the Supabase-hosted database.
-  podcast-rag-db:
-    image: postgres:17
-    container_name: podcast-rag-db
-    restart: unless-stopped
-
-    environment:
-      POSTGRES_USER: podcast_rag
-      POSTGRES_DB: podcast_rag
-      # Substituted from the environment at "docker compose up" time.
-      # Run:  doppler run -- docker compose up -d   (or set it in .env).
-      POSTGRES_PASSWORD: "${LOCAL_DB_PASSWORD}"
-
-    # Published to localhost only, for host-side admin tooling (alembic,
-    # psql, verification scripts). App containers reach the DB over
-    # podcast-rag-net by the service name, not this port.
-    ports:
-      - "127.0.0.1:5432:5432"
-
-    volumes:
-      - pgdata:/var/lib/postgresql/data
-
-    networks:
-      - podcast-rag-net
-
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U podcast_rag -d podcast_rag"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
-
   podcast-rag:
     image: allenhutchison/podcast-rag:latest
     container_name: podcast-rag
     restart: unless-stopped
-
-    # Start only once the local database is accepting connections
-    depends_on:
-      podcast-rag-db:
-        condition: service_healthy
-
-    networks:
-      - podcast-rag-net
 
     # Environment variables
     env_file:
@@ -97,18 +51,9 @@ services:
     container_name: podcast-rag-web
     restart: unless-stopped
 
-    # Start only once the local database is accepting connections
-    depends_on:
-      podcast-rag-db:
-        condition: service_healthy
-
-    networks:
-      - podcast-rag-net
-
-    # Port mapping — localhost only. Public traffic arrives via the
-    # cloudflared service, which reaches this container over podcast-rag-net.
+    # Port mapping
     ports:
-      - "127.0.0.1:8080:8080"
+      - "8080:8080"
 
     # Environment variables
     env_file:
@@ -117,10 +62,6 @@ services:
       - PODCAST_DOWNLOAD_DIRECTORY=/data/podcasts
       - PYTHONUNBUFFERED=1
       - PORT=8080
-      # Only trust X-Forwarded-* headers from the cloudflared sidecar
-      # (Docker bridge networks live in 172.16.0.0/12) or the host
-      # loopback. Overrides the image default of '*'.
-      - UVICORN_FORWARDED_ALLOW_IPS=127.0.0.1,172.16.0.0/12
 
     # Volume mounts (shared with encoding backend)
     volumes:
@@ -161,9 +102,6 @@ services:
     profiles:
       - manual  # Only start manually with --profile manual
 
-    networks:
-      - podcast-rag-net
-
     env_file:
       - .env
     environment:
@@ -181,45 +119,3 @@ services:
       options:
         max-size: "5m"
         max-file: "2"
-
-  # Cloudflare Tunnel — terminates TLS at Cloudflare's edge and forwards
-  # public traffic to podcast-rag-web. Outbound-only: no inbound ports.
-  # Ingress rules (hostname -> http://podcast-rag-web:8080) are managed
-  # in the Cloudflare Zero Trust dashboard for this token's tunnel.
-  cloudflared:
-    image: cloudflare/cloudflared:latest
-    container_name: podcast-rag-cloudflared
-    restart: unless-stopped
-
-    command: tunnel --no-autoupdate run
-
-    environment:
-      # Substituted from the environment at "docker compose up" time.
-      # Run:  doppler run -- docker compose up -d   (or set it in .env).
-      TUNNEL_TOKEN: "${CLOUDFLARE_TUNNEL_TOKEN}"
-
-    # Wait until the web app is responding to /health, not just running —
-    # otherwise the tunnel can start forwarding before the app is ready and
-    # produce transient 502s.
-    depends_on:
-      podcast-rag-web:
-        condition: service_healthy
-
-    networks:
-      - podcast-rag-net
-
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
-
-volumes:
-  # Persistent storage for the local PostgreSQL data directory
-  pgdata:
-    driver: local
-
-networks:
-  # Internal network shared by the database, pipeline, web, and tunnel
-  podcast-rag-net:
-    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,10 @@ services:
       - PODCAST_DOWNLOAD_DIRECTORY=/data/podcasts
       - PYTHONUNBUFFERED=1
       - PORT=8080
+      # Only trust X-Forwarded-* headers from the cloudflared sidecar
+      # (Docker bridge networks live in 172.16.0.0/12) or the host
+      # loopback. Overrides the image default of '*'.
+      - UVICORN_FORWARDED_ALLOW_IPS=127.0.0.1,172.16.0.0/12
 
     # Volume mounts (shared with encoding backend)
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,8 +194,12 @@ services:
       # Run:  doppler run -- docker compose up -d   (or set it in .env).
       TUNNEL_TOKEN: "${CLOUDFLARE_TUNNEL_TOKEN}"
 
+    # Wait until the web app is responding to /health, not just running —
+    # otherwise the tunnel can start forwarding before the app is ready and
+    # produce transient 502s.
     depends_on:
-      - podcast-rag-web
+      podcast-rag-web:
+        condition: service_healthy
 
     networks:
       - podcast-rag-net

--- a/docs/deploy-vps.md
+++ b/docs/deploy-vps.md
@@ -1,25 +1,39 @@
-# VPS Deployment & Migration Runbook
+# VPS Deployment & Migration Runbook (bubba)
 
 This guide moves the **database** off Supabase and the **frontend** off Google
-Cloud Run, consolidating the whole stack onto the VPS that already runs the
-transcription pipeline.
+Cloud Run, consolidating the whole stack onto **bubba** (the VPS that already
+runs the transcription pipeline).
 
-After the migration the VPS runs four containers as one Docker Compose stack:
+## Where the infra lives
 
-| Container | Role |
-|---|---|
-| `podcast-rag-db` | Local PostgreSQL 17 (replaces Supabase) |
-| `podcast-rag` | Transcription pipeline (unchanged) |
-| `podcast-rag-web` | FastAPI web app (replaces Cloud Run) |
-| `cloudflared` | Cloudflare Tunnel — public HTTPS ingress, outbound-only |
+The runtime stack on bubba is managed by the **homelab** repo, not this one.
+The relevant pieces:
+
+| Container | Owned by | Role |
+|---|---|---|
+| `podcast-rag-db` | `homelab/compose/docker-compose.podcast-rag.yml` | Local PostgreSQL 17 (replaces Supabase) |
+| `podcast-rag` | `homelab/compose/docker-compose.podcast-rag.yml` | Transcription pipeline (image: `allenhutchison/podcast-rag:latest`) |
+| `podcast-rag-web` | `homelab/compose/docker-compose.podcast-rag.yml` | FastAPI web app (image: `allenhutchison/podcast-rag-web:latest`, replaces Cloud Run) |
+| `cloudflared` | `homelab/compose/docker-compose.podcast-rag.yml` | Cloudflare Tunnel — public HTTPS ingress, outbound-only |
+
+What lives in **this** repo:
+
+- `Dockerfile.web` — the `--proxy-headers` / `UVICORN_FORWARDED_ALLOW_IPS` change
+  that makes uvicorn trust the cloudflared sidecar's `X-Forwarded-*` headers.
+  Ships through Watchtower (pulls `:latest` daily).
+- `scripts/migrate-prod-db.sh`, `scripts/verify-db-clone.sh`,
+  `scripts/backup-db.sh` — compose-project-agnostic (raw `docker exec` against
+  the fixed container name `podcast-rag-db`), so they work whether the
+  container is owned by this repo's `docker-compose.yml` or by the homelab
+  stack.
 
 ```text
 Internet ──HTTPS──> Cloudflare edge ──tunnel──> cloudflared ─┐
-                                                             │ podcast-rag-net
-        ┌────────────────────────────────────────────────────┤ (internal)
+                                                             │ default compose net
+        ┌────────────────────────────────────────────────────┤
    podcast-rag-web:8080      podcast-rag (pipeline)      podcast-rag-db:5432
-                                                              │ volume: pgdata
-                                            127.0.0.1:5432 ──>┘ (host admin only)
+   (127.0.0.1:8080 on host)                                   │ volume: podcast_rag_db_data
+                                              127.0.0.1:5432 ─┘ (host admin only)
 ```
 
 Gemini File Search is unaffected — it is Google-hosted and holds no data in this
@@ -30,57 +44,55 @@ users, chat history, and briefings.
 
 ## Prerequisites
 
-- VPS with Docker + Docker Compose, already running the `podcast-rag` pipeline.
-- Doppler CLI on the VPS, with access to the **`prod`** config.
+- bubba: Docker + Docker Compose, already running the `podcast-rag` pipeline
+  under the homelab stack (`~/src/homelab/nodes/bubba.sh`).
+- Doppler CLI on bubba, with access to the **`prod`** config of the
+  `podcast-rag` project.
+- Working copy of `~/src/homelab` and `~/src/podcast-rag`.
 - A Cloudflare account with the web app's domain as a zone.
-- `ffmpeg` (already present for the pipeline).
 
-## New Doppler secrets (config: `prod`)
+## New secrets
 
-Add these to the `prod` config before starting:
+Add these to `~/src/homelab/compose/podcast-rag.env` (also push to the
+1Password environment for this service per `homelab/CLAUDE.md`):
 
-| Secret | Value |
+| Key | Value |
 |---|---|
-| `LOCAL_DB_PASSWORD` | A freshly generated strong password for the local DB |
-| `CLOUDFLARE_TUNNEL_TOKEN` | The token for the Cloudflare Tunnel (created in Phase 3) |
-| `DOPPLER_TOKEN` | A Doppler **service token** for `prod` — lets the web/pipeline containers self-inject secrets via `docker-entrypoint.sh` |
+| `POSTGRES_USER` | `podcast_rag` |
+| `POSTGRES_DB` | `podcast_rag` |
+| `POSTGRES_PASSWORD` | A freshly generated strong password for the local DB |
+| `TUNNEL_TOKEN` | The token for the Cloudflare Tunnel (created in Phase 3) |
 
-`DATABASE_URL` is **changed** during cutover (Phase 4), not now. Recommended
-final value, using a Doppler secret reference so the password has one source of
-truth:
+`DATABASE_URL` lives in **Doppler `prod`** and is **changed during cutover
+(Phase 4)**, not now. Recommended final value:
 
 ```dotenv
-DATABASE_URL = postgresql://podcast_rag:${LOCAL_DB_PASSWORD}@podcast-rag-db:5432/podcast_rag
+DATABASE_URL=postgresql://podcast_rag:<POSTGRES_PASSWORD>@podcast-rag-db:5432/podcast_rag
 ```
 
-> The host `podcast-rag-db` only resolves **inside** `podcast-rag-net`. For
-> host-side tooling (Alembic, psql) use `127.0.0.1:5432` instead — see the note
-> at the end.
-
-**Always run compose under Doppler** so `LOCAL_DB_PASSWORD` and
-`CLOUDFLARE_TUNNEL_TOKEN` are available for variable substitution:
-
-```bash
-doppler run -- docker compose up -d <service>
-```
+> The host `podcast-rag-db` only resolves **inside** the compose network. For
+> host-side tooling (Alembic, psql) use `127.0.0.1:5432` instead — see
+> *Operations* at the end.
 
 ---
 
 ## Phase 1 — Stand up local PostgreSQL (no downtime)
 
-1. Add `LOCAL_DB_PASSWORD` to Doppler `prod`.
-2. Start the database container:
+1. Update `~/src/homelab/compose/podcast-rag.env` with `POSTGRES_*` (see above).
+2. From `~/src/homelab`:
    ```bash
-   doppler run -- docker compose up -d podcast-rag-db
-   docker compose ps          # wait for "(healthy)"
+   ./nodes/bubba.sh up -d podcast-rag-db
+   docker ps --filter name=podcast-rag-db   # wait for "(healthy)"
    ```
 
-The `pgdata` named volume persists the data directory across restarts.
+The `podcast_rag_db_data` named volume persists the data directory across
+restarts.
 
 ## Phase 2 — Clone tooling & rehearsal (no downtime)
 
 While Supabase is still live and serving production, rehearse the clone so the
-tooling is proven before the real maintenance window.
+tooling is proven before the real maintenance window. Run these from
+`~/src/podcast-rag`:
 
 1. Clone production into the local DB:
    ```bash
@@ -100,29 +112,33 @@ tooling is proven before the real maintenance window.
    clean run succeeds. (The rehearsal clone is overwritten by the real one in
    Phase 4, so a stale rehearsal is harmless.)
 
-## Phase 3 — Web app on the VPS + Cloudflare Tunnel (no downtime)
+## Phase 3 — Cloudflare Tunnel + web smoke test (no downtime)
+
+Production traffic still lives on Cloud Run at this point. We bring up
+cloudflared pointing at the bubba web container, smoke-test through a
+**temporary** hostname, and leave the production DNS alone until Phase 4.
 
 1. **Create the tunnel.** In the Cloudflare dashboard → Zero Trust → Networks →
-   Tunnels, create a tunnel, copy its **token** into Doppler `prod` as
-   `CLOUDFLARE_TUNNEL_TOKEN`. Add a **public hostname** route:
+   Tunnels, create a tunnel, copy its **token** into
+   `~/src/homelab/compose/podcast-rag.env` as `TUNNEL_TOKEN`. Add a
+   **public hostname** route:
    - Temporary test hostname (e.g. `vps-test.<your-domain>`) → service
-     `http://podcast-rag-web:8080`.
-2. **Build/pull the web image.** Push a git tag to build via
-   `.github/workflows/docker-release.yml`, or build on the VPS:
+     `http://podcast-rag-web:8080` (the compose service name, not localhost).
+2. **Pull the new web image.** The `--proxy-headers` change ships with
+   `allenhutchison/podcast-rag-web:latest`; Watchtower pulls it daily at 3 AM,
+   or force it:
    ```bash
-   docker compose build podcast-rag-web   # or: docker compose pull
+   ./nodes/bubba.sh pull podcast-rag-web
+   ./nodes/bubba.sh up -d podcast-rag-web   # recreate with new image + tightened UVICORN_FORWARDED_ALLOW_IPS
    ```
-   The image's uvicorn command now includes `--proxy-headers
-   --forwarded-allow-ips=*` so OAuth, Secure cookies, and rate limiting work
-   correctly behind the tunnel.
 3. **Register the OAuth redirect URI.** In Google Cloud Console, add
    `https://vps-test.<your-domain>/auth/callback` as an authorized redirect URI
    (temporary, for testing). The production URI should already be registered.
-4. **Start web + tunnel, still pointed at Supabase** (`DATABASE_URL` unchanged):
+4. **Start cloudflared, still pointed at Supabase** (`DATABASE_URL` unchanged):
    ```bash
-   doppler run -- docker compose up -d podcast-rag-web cloudflared
+   ./nodes/bubba.sh up -d cloudflared
    ```
-5. **Smoke-test the VPS app** over the test hostname before touching the
+5. **Smoke-test the bubba app** over the test hostname before touching the
    database or production DNS:
    - `https://vps-test.<your-domain>/health` → healthy
    - Google OAuth login round-trips
@@ -133,12 +149,16 @@ tooling is proven before the real maintenance window.
 ## Phase 4 — Cutover (maintenance window, a few minutes)
 
 1. **Freeze writes to Supabase:**
-   ```bash
-   docker compose stop podcast-rag          # stop the pipeline
-   ```
-   Stop public traffic to the Cloud Run app (set min/max instances to 0 in the
-   Cloud Run console — full deletion is Phase 5).
-2. **Final clone** of the now-quiescent production database:
+   - Stop the Cloud Run app first (set min/max instances to 0 in the Cloud Run
+     console — full deletion is Phase 5). This is the most important step:
+     once `DATABASE_URL` flips in Doppler, any still-running Cloud Run instance
+     would try to reach `podcast-rag-db:5432`, which it can't resolve.
+   - Stop the bubba pipeline:
+     ```bash
+     ./nodes/bubba.sh stop podcast-rag
+     ```
+2. **Final clone** of the now-quiescent production database (from
+   `~/src/podcast-rag`):
    ```bash
    ./scripts/migrate-prod-db.sh
    ```
@@ -148,36 +168,36 @@ tooling is proven before the real maintenance window.
    ```
    Proceed **only** if it exits 0. If not, see *Rollback*.
 4. **Repoint the app** — change `DATABASE_URL` in Doppler `prod` to the local
-   value (see *New Doppler secrets* above).
-5. **Restart everything on the local DB:**
+   value (see *New secrets* above).
+5. **Restart everything on the local DB** (from `~/src/homelab`):
    ```bash
-   doppler run -- docker compose up -d
+   ./nodes/bubba.sh up -d
    ```
-6. **Confirm schema head** against the local DB — the container now resolves
-   `DATABASE_URL` to the local database (expected: no-op, already at head, since
-   `verify-db-clone.sh` already confirmed the Alembic version):
+   The web and pipeline containers re-read Doppler at start and now connect to
+   `podcast-rag-db:5432`.
+6. **Confirm schema head** against the local DB (expected: no-op, already at
+   head, since `verify-db-clone.sh` already confirmed the Alembic version):
    ```bash
-   docker compose run --rm podcast-rag alembic upgrade head
+   docker exec podcast-rag alembic upgrade head
    ```
 7. **Switch DNS** — in the Cloudflare tunnel, change the **production** hostname
    route to `http://podcast-rag-web:8080` (and remove the temp `vps-test`
    route).
 8. **Smoke-test production:**
    - Site loads over HTTPS, OAuth login works, a chat query works.
-   - `docker compose run --rm podcast-rag python -m src.cli podcast status`
+   - `docker exec podcast-rag python -m src.cli podcast status`
      shows the expected episode/indexing counts.
-   - `docker compose logs -f podcast-rag` shows the pipeline writing to the
-     local DB.
+   - `docker logs -f podcast-rag` shows the pipeline writing to the local DB.
 
 ## Phase 5 — Decommission & hardening (after stable operation)
 
 1. **Schedule local backups** (replaces Supabase's managed backups):
    ```bash
    crontab -e
-   # 15 3 * * * cd /opt/podcast-rag && /opt/podcast-rag/scripts/backup-db.sh >> /var/log/podcast-rag-backup.log 2>&1
+   # 15 3 * * * cd /home/allen/src/podcast-rag && /home/allen/src/podcast-rag/scripts/backup-db.sh >> /var/log/podcast-rag-backup.log 2>&1
    ```
-   Copy `./backups/` off-box (rsync/object storage) — the VPS is now a single
-   point of failure for the DB.
+   Decide on and set up off-box backup destination (rsync to another host,
+   object storage, etc.) — bubba is now a single point of failure for the DB.
 2. **Retire Cloud Run:** delete the Cloud Run service and its Cloud Build
    trigger, then delete `cloudbuild.yaml` from the repo. Remove the temporary
    `vps-test` OAuth redirect URI from Google Cloud Console.
@@ -190,15 +210,15 @@ tooling is proven before the real maintenance window.
 ## Rollback
 
 Because the pipeline is stopped and Supabase is untouched after its final dump,
-nothing is written to the local DB until Phase 4 step 6 — so rollback is clean
+nothing is written to the local DB until Phase 4 step 5 — so rollback is clean
 within the window:
 
 - **Verification fails (step 3):** abort the cutover. Restart the pipeline
-  (`docker compose start podcast-rag`) and re-enable Cloud Run. Investigate, fix
-  `migrate-prod-db.sh`, and retry.
+  (`./nodes/bubba.sh start podcast-rag`) and re-enable Cloud Run. Investigate,
+  fix `migrate-prod-db.sh`, and retry.
 - **App breaks after cutover:** revert `DATABASE_URL` in Doppler back to the
-  Supabase URL, `doppler run -- docker compose up -d`, and re-point the tunnel /
-  re-enable Cloud Run. Any writes made to the local DB after step 6 are lost on
+  Supabase URL, `./nodes/bubba.sh up -d`, and re-point the tunnel /
+  re-enable Cloud Run. Any writes made to the local DB after step 5 are lost on
   this path — so run the smoke tests promptly.
 
 Supabase is kept as a **point-in-time standby for ~2 weeks**. It is a snapshot,
@@ -208,21 +228,22 @@ not a live replica: a rollback after the window loses post-cutover data.
 
 ## Operations
 
-**Backup now:** `./scripts/backup-db.sh`
+**Backup now:** `./scripts/backup-db.sh` (from `~/src/podcast-rag`)
 
 **Restore from a backup:**
 ```bash
 gunzip -c backups/podcast_rag_YYYYMMDD_HHMMSS.sql.gz \
-  | docker compose exec -T podcast-rag-db psql -v ON_ERROR_STOP=1 -U podcast_rag -d podcast_rag
+  | docker exec -i podcast-rag-db psql -v ON_ERROR_STOP=1 -U podcast_rag -d podcast_rag
 ```
 
 **Host-side Alembic / psql** — the Doppler `DATABASE_URL` uses the Docker
 network host `podcast-rag-db`, which the host shell cannot resolve. Either run
-inside a container (`docker compose run --rm podcast-rag alembic ...`) or
-override for host runs — `alembic/env.py` prefers `ALEMBIC_DATABASE_URL`:
+inside a container (`docker exec podcast-rag alembic ...`) or override for
+host runs — `alembic/env.py` prefers `ALEMBIC_DATABASE_URL`:
 ```bash
-ALEMBIC_DATABASE_URL="postgresql://podcast_rag:$LOCAL_DB_PASSWORD@127.0.0.1:5432/podcast_rag" \
+ALEMBIC_DATABASE_URL="postgresql://podcast_rag:$POSTGRES_PASSWORD@127.0.0.1:5432/podcast_rag" \
   alembic upgrade head
 ```
 
-**Logs:** `docker compose logs -f podcast-rag-web cloudflared podcast-rag-db`
+**Logs:** `docker logs -f podcast-rag-web` (or `podcast-rag`, `podcast-rag-db`,
+`podcast-rag-cloudflared`)

--- a/docs/deploy-vps.md
+++ b/docs/deploy-vps.md
@@ -13,7 +13,7 @@ After the migration the VPS runs four containers as one Docker Compose stack:
 | `podcast-rag-web` | FastAPI web app (replaces Cloud Run) |
 | `cloudflared` | Cloudflare Tunnel — public HTTPS ingress, outbound-only |
 
-```
+```text
 Internet ──HTTPS──> Cloudflare edge ──tunnel──> cloudflared ─┐
                                                              │ podcast-rag-net
         ┌────────────────────────────────────────────────────┤ (internal)
@@ -49,7 +49,7 @@ Add these to the `prod` config before starting:
 final value, using a Doppler secret reference so the password has one source of
 truth:
 
-```
+```dotenv
 DATABASE_URL = postgresql://podcast_rag:${LOCAL_DB_PASSWORD}@podcast-rag-db:5432/podcast_rag
 ```
 

--- a/docs/deploy-vps.md
+++ b/docs/deploy-vps.md
@@ -1,0 +1,228 @@
+# VPS Deployment & Migration Runbook
+
+This guide moves the **database** off Supabase and the **frontend** off Google
+Cloud Run, consolidating the whole stack onto the VPS that already runs the
+transcription pipeline.
+
+After the migration the VPS runs four containers as one Docker Compose stack:
+
+| Container | Role |
+|---|---|
+| `podcast-rag-db` | Local PostgreSQL 17 (replaces Supabase) |
+| `podcast-rag` | Transcription pipeline (unchanged) |
+| `podcast-rag-web` | FastAPI web app (replaces Cloud Run) |
+| `cloudflared` | Cloudflare Tunnel — public HTTPS ingress, outbound-only |
+
+```
+Internet ──HTTPS──> Cloudflare edge ──tunnel──> cloudflared ─┐
+                                                             │ podcast-rag-net
+        ┌────────────────────────────────────────────────────┤ (internal)
+   podcast-rag-web:8080      podcast-rag (pipeline)      podcast-rag-db:5432
+                                                              │ volume: pgdata
+                                            127.0.0.1:5432 ──>┘ (host admin only)
+```
+
+Gemini File Search is unaffected — it is Google-hosted and holds no data in this
+database. The database stores only podcast/episode metadata, indexing status,
+users, chat history, and briefings.
+
+---
+
+## Prerequisites
+
+- VPS with Docker + Docker Compose, already running the `podcast-rag` pipeline.
+- Doppler CLI on the VPS, with access to the **`prod`** config.
+- A Cloudflare account with the web app's domain as a zone.
+- `ffmpeg` (already present for the pipeline).
+
+## New Doppler secrets (config: `prod`)
+
+Add these to the `prod` config before starting:
+
+| Secret | Value |
+|---|---|
+| `LOCAL_DB_PASSWORD` | A freshly generated strong password for the local DB |
+| `CLOUDFLARE_TUNNEL_TOKEN` | The token for the Cloudflare Tunnel (created in Phase 3) |
+| `DOPPLER_TOKEN` | A Doppler **service token** for `prod` — lets the web/pipeline containers self-inject secrets via `docker-entrypoint.sh` |
+
+`DATABASE_URL` is **changed** during cutover (Phase 4), not now. Recommended
+final value, using a Doppler secret reference so the password has one source of
+truth:
+
+```
+DATABASE_URL = postgresql://podcast_rag:${LOCAL_DB_PASSWORD}@podcast-rag-db:5432/podcast_rag
+```
+
+> The host `podcast-rag-db` only resolves **inside** `podcast-rag-net`. For
+> host-side tooling (Alembic, psql) use `127.0.0.1:5432` instead — see the note
+> at the end.
+
+**Always run compose under Doppler** so `LOCAL_DB_PASSWORD` and
+`CLOUDFLARE_TUNNEL_TOKEN` are available for variable substitution:
+
+```bash
+doppler run -- docker compose up -d <service>
+```
+
+---
+
+## Phase 1 — Stand up local PostgreSQL (no downtime)
+
+1. Add `LOCAL_DB_PASSWORD` to Doppler `prod`.
+2. Start the database container:
+   ```bash
+   doppler run -- docker compose up -d podcast-rag-db
+   docker compose ps          # wait for "(healthy)"
+   ```
+
+The `pgdata` named volume persists the data directory across restarts.
+
+## Phase 2 — Clone tooling & rehearsal (no downtime)
+
+While Supabase is still live and serving production, rehearse the clone so the
+tooling is proven before the real maintenance window.
+
+1. Clone production into the local DB:
+   ```bash
+   ./scripts/migrate-prod-db.sh
+   ```
+   It dumps Supabase (rewriting the pooler port `6543`→`5432` for `pg_dump`),
+   drops/recreates the local `podcast_rag` database, and restores with
+   `ON_ERROR_STOP=1 --single-transaction` — any error aborts loudly.
+2. Verify the clone:
+   ```bash
+   ./scripts/verify-db-clone.sh
+   ```
+   It compares Alembic version, table inventory, per-table row counts, an
+   order-independent per-table content checksum, and sequence values. It must
+   print **`VERIFICATION PASSED`** and exit 0.
+3. If verification fails, fix the cause and repeat. Do not continue until a
+   clean run succeeds. (The rehearsal clone is overwritten by the real one in
+   Phase 4, so a stale rehearsal is harmless.)
+
+## Phase 3 — Web app on the VPS + Cloudflare Tunnel (no downtime)
+
+1. **Create the tunnel.** In the Cloudflare dashboard → Zero Trust → Networks →
+   Tunnels, create a tunnel, copy its **token** into Doppler `prod` as
+   `CLOUDFLARE_TUNNEL_TOKEN`. Add a **public hostname** route:
+   - Temporary test hostname (e.g. `vps-test.<your-domain>`) → service
+     `http://podcast-rag-web:8080`.
+2. **Build/pull the web image.** Push a git tag to build via
+   `.github/workflows/docker-release.yml`, or build on the VPS:
+   ```bash
+   docker compose build podcast-rag-web   # or: docker compose pull
+   ```
+   The image's uvicorn command now includes `--proxy-headers
+   --forwarded-allow-ips=*` so OAuth, Secure cookies, and rate limiting work
+   correctly behind the tunnel.
+3. **Register the OAuth redirect URI.** In Google Cloud Console, add
+   `https://vps-test.<your-domain>/auth/callback` as an authorized redirect URI
+   (temporary, for testing). The production URI should already be registered.
+4. **Start web + tunnel, still pointed at Supabase** (`DATABASE_URL` unchanged):
+   ```bash
+   doppler run -- docker compose up -d podcast-rag-web cloudflared
+   ```
+5. **Smoke-test the VPS app** over the test hostname before touching the
+   database or production DNS:
+   - `https://vps-test.<your-domain>/health` → healthy
+   - Google OAuth login round-trips
+   - A chat query streams a response with citations
+6. Confirm `WEB_BASE_URL` in Doppler `prod` equals the **final production**
+   hostname, so `WEB_BASE_URL/auth/callback` stays a registered redirect URI.
+
+## Phase 4 — Cutover (maintenance window, a few minutes)
+
+1. **Freeze writes to Supabase:**
+   ```bash
+   docker compose stop podcast-rag          # stop the pipeline
+   ```
+   Stop public traffic to the Cloud Run app (set min/max instances to 0 in the
+   Cloud Run console — full deletion is Phase 5).
+2. **Final clone** of the now-quiescent production database:
+   ```bash
+   ./scripts/migrate-prod-db.sh
+   ```
+3. **Verify — the gate for the rest of cutover:**
+   ```bash
+   ./scripts/verify-db-clone.sh
+   ```
+   Proceed **only** if it exits 0. If not, see *Rollback*.
+4. **Repoint the app** — change `DATABASE_URL` in Doppler `prod` to the local
+   value (see *New Doppler secrets* above).
+5. **Restart everything on the local DB:**
+   ```bash
+   doppler run -- docker compose up -d
+   ```
+6. **Confirm schema head** against the local DB — the container now resolves
+   `DATABASE_URL` to the local database (expected: no-op, already at head, since
+   `verify-db-clone.sh` already confirmed the Alembic version):
+   ```bash
+   docker compose run --rm podcast-rag alembic upgrade head
+   ```
+7. **Switch DNS** — in the Cloudflare tunnel, change the **production** hostname
+   route to `http://podcast-rag-web:8080` (and remove the temp `vps-test`
+   route).
+8. **Smoke-test production:**
+   - Site loads over HTTPS, OAuth login works, a chat query works.
+   - `docker compose run --rm podcast-rag python -m src.cli podcast status`
+     shows the expected episode/indexing counts.
+   - `docker compose logs -f podcast-rag` shows the pipeline writing to the
+     local DB.
+
+## Phase 5 — Decommission & hardening (after stable operation)
+
+1. **Schedule local backups** (replaces Supabase's managed backups):
+   ```bash
+   crontab -e
+   # 15 3 * * * cd /opt/podcast-rag && /opt/podcast-rag/scripts/backup-db.sh >> /var/log/podcast-rag-backup.log 2>&1
+   ```
+   Copy `./backups/` off-box (rsync/object storage) — the VPS is now a single
+   point of failure for the DB.
+2. **Retire Cloud Run:** delete the Cloud Run service and its Cloud Build
+   trigger, then delete `cloudbuild.yaml` from the repo. Remove the temporary
+   `vps-test` OAuth redirect URI from Google Cloud Console.
+3. **Update docs:** `AGENTS.md`, `docs/deploy-quick-start.md`, and
+   `docs/WEB_ARCHITECTURE.md` still describe the Cloud Run deployment.
+4. **After ~2 weeks** of stable operation, delete or pause the Supabase project.
+
+---
+
+## Rollback
+
+Because the pipeline is stopped and Supabase is untouched after its final dump,
+nothing is written to the local DB until Phase 4 step 6 — so rollback is clean
+within the window:
+
+- **Verification fails (step 3):** abort the cutover. Restart the pipeline
+  (`docker compose start podcast-rag`) and re-enable Cloud Run. Investigate, fix
+  `migrate-prod-db.sh`, and retry.
+- **App breaks after cutover:** revert `DATABASE_URL` in Doppler back to the
+  Supabase URL, `doppler run -- docker compose up -d`, and re-point the tunnel /
+  re-enable Cloud Run. Any writes made to the local DB after step 6 are lost on
+  this path — so run the smoke tests promptly.
+
+Supabase is kept as a **point-in-time standby for ~2 weeks**. It is a snapshot,
+not a live replica: a rollback after the window loses post-cutover data.
+
+---
+
+## Operations
+
+**Backup now:** `./scripts/backup-db.sh`
+
+**Restore from a backup:**
+```bash
+gunzip -c backups/podcast_rag_YYYYMMDD_HHMMSS.sql.gz \
+  | docker compose exec -T podcast-rag-db psql -v ON_ERROR_STOP=1 -U podcast_rag -d podcast_rag
+```
+
+**Host-side Alembic / psql** — the Doppler `DATABASE_URL` uses the Docker
+network host `podcast-rag-db`, which the host shell cannot resolve. Either run
+inside a container (`docker compose run --rm podcast-rag alembic ...`) or
+override for host runs — `alembic/env.py` prefers `ALEMBIC_DATABASE_URL`:
+```bash
+ALEMBIC_DATABASE_URL="postgresql://podcast_rag:$LOCAL_DB_PASSWORD@127.0.0.1:5432/podcast_rag" \
+  alembic upgrade head
+```
+
+**Logs:** `docker compose logs -f podcast-rag-web cloudflared podcast-rag-db`

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# backup-db.sh — Back up the local PostgreSQL database.
+#
+# Dumps the local Dockerized database (the `podcast-rag-db` service) to a
+# timestamped, gzip-compressed file and prunes old backups. This replaces
+# the managed backups Supabase provided before the migration, so it should
+# run on a schedule (see the cron example below).
+#
+# Usage:
+#   ./scripts/backup-db.sh
+#
+# Environment overrides:
+#   BACKUP_DIR      Destination directory   (default: ./backups)
+#   RETENTION_DAYS  Delete backups older than this many days (default: 14)
+#
+# Cron example (nightly at 03:15 — note the cd, cron has a minimal PATH):
+#   15 3 * * * cd /opt/podcast-rag && /opt/podcast-rag/scripts/backup-db.sh >> /var/log/podcast-rag-backup.log 2>&1
+#
+set -euo pipefail
+
+# ── Resolve repo root so `docker compose` finds docker-compose.yml ─────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+DB_SERVICE="podcast-rag-db"
+LOCAL_DB_USER="podcast_rag"
+LOCAL_DB_NAME="podcast_rag"
+BACKUP_DIR="${BACKUP_DIR:-$REPO_ROOT/backups}"
+RETENTION_DAYS="${RETENTION_DAYS:-14}"
+
+mkdir -p "$BACKUP_DIR"
+
+TS="$(date +%Y%m%d_%H%M%S)"
+OUT_FILE="$BACKUP_DIR/podcast_rag_${TS}.sql.gz"
+
+# ── Dump (pipefail makes a pg_dump failure fail the whole pipeline) ───────
+echo "==> Backing up '$LOCAL_DB_NAME' to $OUT_FILE ..."
+docker compose exec -T "$DB_SERVICE" \
+    pg_dump --no-owner --no-privileges -U "$LOCAL_DB_USER" "$LOCAL_DB_NAME" \
+    | gzip > "$OUT_FILE"
+
+if [[ ! -s "$OUT_FILE" ]]; then
+    echo "ERROR: backup file is empty — removing it." >&2
+    rm -f "$OUT_FILE"
+    exit 1
+fi
+echo "    Backup complete: $(du -h "$OUT_FILE" | cut -f1)"
+
+# ── Prune old backups ─────────────────────────────────────────────────────
+echo "==> Pruning backups older than $RETENTION_DAYS days..."
+find "$BACKUP_DIR" -maxdepth 1 -name 'podcast_rag_*.sql.gz' -type f \
+    -mtime "+$RETENTION_DAYS" -print -delete
+
+REMAINING="$(find "$BACKUP_DIR" -maxdepth 1 -name 'podcast_rag_*.sql.gz' -type f | wc -l | tr -d ' ')"
+echo "    Done. $REMAINING backup(s) retained in $BACKUP_DIR"

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -2,10 +2,14 @@
 #
 # backup-db.sh — Back up the local PostgreSQL database.
 #
-# Dumps the local Dockerized database (the `podcast-rag-db` service) to a
+# Dumps the local PostgreSQL container named `podcast-rag-db` to a
 # timestamped, gzip-compressed file and prunes old backups. This replaces
 # the managed backups Supabase provided before the migration, so it should
 # run on a schedule (see the cron example below).
+#
+# Compose-project-agnostic: uses raw `docker exec` against the fixed
+# container name, so it doesn't care which compose stack started the
+# container (this repo's, or homelab/'s on bubba).
 #
 # Usage:
 #   ./scripts/backup-db.sh
@@ -15,7 +19,7 @@
 #   RETENTION_DAYS  Delete backups older than this many days (default: 14)
 #
 # Cron example (nightly at 03:15 — note the cd, cron has a minimal PATH):
-#   15 3 * * * cd /opt/podcast-rag && /opt/podcast-rag/scripts/backup-db.sh >> /var/log/podcast-rag-backup.log 2>&1
+#   15 3 * * * cd /home/allen/src/podcast-rag && /home/allen/src/podcast-rag/scripts/backup-db.sh >> /var/log/podcast-rag-backup.log 2>&1
 #
 set -euo pipefail
 
@@ -23,12 +27,11 @@ set -euo pipefail
 # and every file this script creates (mkdir, the gzip output, etc.).
 umask 077
 
-# ── Resolve repo root so `docker compose` finds docker-compose.yml ─────────
+# ── Resolve repo root (only used to default BACKUP_DIR) ──────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-cd "$REPO_ROOT"
 
-DB_SERVICE="podcast-rag-db"
+DB_CONTAINER="podcast-rag-db"
 LOCAL_DB_USER="podcast_rag"
 LOCAL_DB_NAME="podcast_rag"
 BACKUP_DIR="${BACKUP_DIR:-$REPO_ROOT/backups}"
@@ -41,7 +44,7 @@ OUT_FILE="$BACKUP_DIR/podcast_rag_${TS}.sql.gz"
 
 # ── Dump (pipefail makes a pg_dump failure fail the whole pipeline) ───────
 echo "==> Backing up '$LOCAL_DB_NAME' to $OUT_FILE ..."
-docker compose exec -T "$DB_SERVICE" \
+docker exec "$DB_CONTAINER" \
     pg_dump --no-owner --no-privileges -U "$LOCAL_DB_USER" "$LOCAL_DB_NAME" \
     | gzip > "$OUT_FILE"
 

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -19,6 +19,10 @@
 #
 set -euo pipefail
 
+# Backups contain production data; restrict permissions on the directory
+# and every file this script creates (mkdir, the gzip output, etc.).
+umask 077
+
 # ── Resolve repo root so `docker compose` finds docker-compose.yml ─────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"

--- a/scripts/migrate-prod-db.sh
+++ b/scripts/migrate-prod-db.sh
@@ -3,7 +3,12 @@
 # migrate-prod-db.sh — One-time production clone.
 #
 # Dumps the Supabase-hosted production database and restores it into the
-# local Dockerized PostgreSQL (the `podcast-rag-db` service) on the VPS.
+# local PostgreSQL container named `podcast-rag-db` on the VPS.
+#
+# Compose-project-agnostic: the script uses raw `docker exec` against the
+# fixed container name, so it doesn't care whether the container was started
+# by this repo's docker-compose.yml or by the homelab repo's compose stack
+# (which is the case on bubba).
 #
 # Unlike scripts/sync-dev-db.sh (a dev convenience that suppresses errors),
 # this script FAILS LOUDLY: any pg_dump or psql error aborts the run, so a
@@ -17,23 +22,16 @@
 #
 # Prerequisites:
 #   - The podcast-rag-db container is running and healthy
-#     (doppler run -- docker compose up -d podcast-rag-db)
 #   - Doppler CLI configured with access to the `prod` config
 #   - Docker available (the postgres:17 image is used for pg_dump)
 #
 set -euo pipefail
 
-# ── Resolve repo root so `docker compose` finds docker-compose.yml ─────────
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-cd "$REPO_ROOT"
-
 # ── Configuration ─────────────────────────────────────────────────────────
-DB_SERVICE="podcast-rag-db"      # docker-compose service name
+DB_CONTAINER="podcast-rag-db"
 LOCAL_DB_USER="podcast_rag"
 LOCAL_DB_NAME="podcast_rag"
 PG_IMAGE="postgres:17"
-COMPOSE=(docker compose)
 
 umask 077
 DUMP_FILE="$(mktemp /tmp/podcast-rag-prod-dump.XXXXXX.sql)"
@@ -67,7 +65,7 @@ echo "    Production URL resolved (credentials hidden)."
 # ── Confirm: this destroys the local podcast_rag database ─────────────────
 echo ""
 echo "    This will DROP and recreate the local '$LOCAL_DB_NAME' database"
-echo "    in the '$DB_SERVICE' container and replace it with a fresh clone"
+echo "    in the '$DB_CONTAINER' container and replace it with a fresh clone"
 echo "    of production. Any existing local data will be lost."
 echo ""
 if ! $ASSUME_YES; then
@@ -80,21 +78,22 @@ if ! $ASSUME_YES; then
 fi
 
 # ── Ensure the local database container is up and healthy ─────────────────
-echo "==> Checking the $DB_SERVICE container..."
-if ! "${COMPOSE[@]}" ps --status running --services 2>/dev/null | grep -qx "$DB_SERVICE"; then
-    echo "ERROR: '$DB_SERVICE' is not running." >&2
-    echo "       Start it with: doppler run -- docker compose up -d $DB_SERVICE" >&2
+echo "==> Checking the $DB_CONTAINER container..."
+if ! docker inspect "$DB_CONTAINER" --format '{{.State.Running}}' 2>/dev/null | grep -qx "true"; then
+    echo "ERROR: container '$DB_CONTAINER' is not running." >&2
+    echo "       Start it from the compose stack that defines it (on bubba:" >&2
+    echo "       ~/src/homelab/nodes/bubba.sh up -d podcast-rag-db)." >&2
     exit 1
 fi
 echo "    Waiting for PostgreSQL to accept connections..."
 MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-120}"
 elapsed=0
-until "${COMPOSE[@]}" exec -T "$DB_SERVICE" pg_isready -U "$LOCAL_DB_USER" -d postgres >/dev/null 2>&1; do
+until docker exec "$DB_CONTAINER" pg_isready -U "$LOCAL_DB_USER" -d postgres >/dev/null 2>&1; do
     sleep 1
     elapsed=$((elapsed + 1))
     if (( elapsed >= MAX_WAIT_SECONDS )); then
-        echo "ERROR: '$DB_SERVICE' (user '$LOCAL_DB_USER') not ready after ${MAX_WAIT_SECONDS}s." >&2
-        echo "       Check 'docker compose logs $DB_SERVICE' for details." >&2
+        echo "ERROR: '$DB_CONTAINER' (user '$LOCAL_DB_USER') not ready after ${MAX_WAIT_SECONDS}s." >&2
+        echo "       Check 'docker logs $DB_CONTAINER' for details." >&2
         exit 1
     fi
 done
@@ -102,7 +101,7 @@ echo "    PostgreSQL is ready."
 
 # Helper: run psql inside the db container against the maintenance database.
 psql_admin() {
-    "${COMPOSE[@]}" exec -T "$DB_SERVICE" \
+    docker exec -i "$DB_CONTAINER" \
         psql -v ON_ERROR_STOP=1 -U "$LOCAL_DB_USER" -d postgres "$@"
 }
 
@@ -137,7 +136,7 @@ psql_admin -c "CREATE DATABASE $LOCAL_DB_NAME OWNER $LOCAL_DB_USER;" >/dev/null
 echo "==> Restoring into the local database..."
 # ON_ERROR_STOP + --single-transaction: any error aborts the whole restore
 # and leaves the database empty rather than half-populated.
-"${COMPOSE[@]}" exec -T "$DB_SERVICE" \
+docker exec -i "$DB_CONTAINER" \
     psql -v ON_ERROR_STOP=1 --single-transaction \
     -U "$LOCAL_DB_USER" -d "$LOCAL_DB_NAME" < "$DUMP_FILE"
 

--- a/scripts/migrate-prod-db.sh
+++ b/scripts/migrate-prod-db.sh
@@ -87,8 +87,16 @@ if ! "${COMPOSE[@]}" ps --status running --services 2>/dev/null | grep -qx "$DB_
     exit 1
 fi
 echo "    Waiting for PostgreSQL to accept connections..."
+MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-120}"
+elapsed=0
 until "${COMPOSE[@]}" exec -T "$DB_SERVICE" pg_isready -U "$LOCAL_DB_USER" -d postgres >/dev/null 2>&1; do
     sleep 1
+    elapsed=$((elapsed + 1))
+    if (( elapsed >= MAX_WAIT_SECONDS )); then
+        echo "ERROR: '$DB_SERVICE' (user '$LOCAL_DB_USER') not ready after ${MAX_WAIT_SECONDS}s." >&2
+        echo "       Check 'docker compose logs $DB_SERVICE' for details." >&2
+        exit 1
+    fi
 done
 echo "    PostgreSQL is ready."
 

--- a/scripts/migrate-prod-db.sh
+++ b/scripts/migrate-prod-db.sh
@@ -100,14 +100,23 @@ done
 echo "    PostgreSQL is ready."
 
 # Helper: run psql inside the db container against the maintenance database.
+# No -i — callers pass SQL via -c, not via stdin. (`docker exec -i` would
+# eat any surrounding heredoc/loop stdin; see verify-db-clone.sh::tgt_q.)
 psql_admin() {
-    docker exec -i "$DB_CONTAINER" \
+    docker exec "$DB_CONTAINER" \
         psql -v ON_ERROR_STOP=1 -U "$LOCAL_DB_USER" -d postgres "$@"
 }
 
 # ── Dump the production database ───────────────────────────────────────────
 echo "==> Dumping production database..."
-DUMP_ARGS=(--no-owner --no-privileges --clean --if-exists)
+# -n public restricts the dump to the public schema. Supabase preloads
+# extensions (hypopg, supabase_vault, etc.) and schemas (auth, storage,
+# realtime, graphql, …) that don't exist in stock postgres:17 and aren't
+# used by this app. Without the filter the restore aborts inside the
+# --single-transaction on the first missing extension. Confirmed safe:
+# `grep -E 'uuid_generate|gen_random|hypopg|...' src/ alembic/` is empty,
+# and no public column default references an extension function.
+DUMP_ARGS=(--no-owner --no-privileges --clean --if-exists -n public)
 if $SCHEMA_ONLY; then
     DUMP_ARGS+=(--schema-only)
     echo "    (schema only — no data)"

--- a/scripts/migrate-prod-db.sh
+++ b/scripts/migrate-prod-db.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# migrate-prod-db.sh — One-time production clone.
+#
+# Dumps the Supabase-hosted production database and restores it into the
+# local Dockerized PostgreSQL (the `podcast-rag-db` service) on the VPS.
+#
+# Unlike scripts/sync-dev-db.sh (a dev convenience that suppresses errors),
+# this script FAILS LOUDLY: any pg_dump or psql error aborts the run, so a
+# partial or corrupt clone can never pass silently. Always follow a run
+# with scripts/verify-db-clone.sh before cutting over.
+#
+# Usage:
+#   ./scripts/migrate-prod-db.sh            # full clone (schema + data)
+#   ./scripts/migrate-prod-db.sh --schema   # schema only, no data
+#   ./scripts/migrate-prod-db.sh --yes      # skip the confirmation prompt
+#
+# Prerequisites:
+#   - The podcast-rag-db container is running and healthy
+#     (doppler run -- docker compose up -d podcast-rag-db)
+#   - Doppler CLI configured with access to the `prod` config
+#   - Docker available (the postgres:17 image is used for pg_dump)
+#
+set -euo pipefail
+
+# ── Resolve repo root so `docker compose` finds docker-compose.yml ─────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+# ── Configuration ─────────────────────────────────────────────────────────
+DB_SERVICE="podcast-rag-db"      # docker-compose service name
+LOCAL_DB_USER="podcast_rag"
+LOCAL_DB_NAME="podcast_rag"
+PG_IMAGE="postgres:17"
+COMPOSE=(docker compose)
+
+umask 077
+DUMP_FILE="$(mktemp /tmp/podcast-rag-prod-dump.XXXXXX.sql)"
+trap 'rm -f "$DUMP_FILE"' EXIT INT TERM
+
+# ── Parse arguments ───────────────────────────────────────────────────────
+SCHEMA_ONLY=false
+ASSUME_YES=false
+for arg in "$@"; do
+    case "$arg" in
+        --schema) SCHEMA_ONLY=true ;;
+        --yes|-y) ASSUME_YES=true ;;
+        *) echo "ERROR: unknown argument '$arg'" >&2; exit 2 ;;
+    esac
+done
+
+# ── Resolve production DATABASE_URL from Doppler ──────────────────────────
+echo "==> Fetching production DATABASE_URL from Doppler (config: prod)..."
+PROD_URL="$(doppler secrets get DATABASE_URL --plain --config prod 2>/dev/null || true)"
+if [[ -z "$PROD_URL" ]]; then
+    echo "ERROR: Could not retrieve DATABASE_URL from Doppler (config: prod)." >&2
+    echo "       Run 'doppler setup' and confirm access to the prod config." >&2
+    exit 1
+fi
+
+# Supabase pooler URLs use port 6543 (transaction mode) or 5432 (session
+# mode). pg_dump requires session mode, so rewrite the port if needed.
+DUMP_URL="${PROD_URL//:6543/:5432}"
+echo "    Production URL resolved (credentials hidden)."
+
+# ── Confirm: this destroys the local podcast_rag database ─────────────────
+echo ""
+echo "    This will DROP and recreate the local '$LOCAL_DB_NAME' database"
+echo "    in the '$DB_SERVICE' container and replace it with a fresh clone"
+echo "    of production. Any existing local data will be lost."
+echo ""
+if ! $ASSUME_YES; then
+    if [[ ! -t 0 ]]; then
+        echo "ERROR: not an interactive shell; re-run with --yes to proceed." >&2
+        exit 1
+    fi
+    read -r -p "Type 'yes' to continue: " reply
+    [[ "$reply" == "yes" ]] || { echo "Aborted."; exit 1; }
+fi
+
+# ── Ensure the local database container is up and healthy ─────────────────
+echo "==> Checking the $DB_SERVICE container..."
+if ! "${COMPOSE[@]}" ps --status running --services 2>/dev/null | grep -qx "$DB_SERVICE"; then
+    echo "ERROR: '$DB_SERVICE' is not running." >&2
+    echo "       Start it with: doppler run -- docker compose up -d $DB_SERVICE" >&2
+    exit 1
+fi
+echo "    Waiting for PostgreSQL to accept connections..."
+until "${COMPOSE[@]}" exec -T "$DB_SERVICE" pg_isready -U "$LOCAL_DB_USER" -d postgres >/dev/null 2>&1; do
+    sleep 1
+done
+echo "    PostgreSQL is ready."
+
+# Helper: run psql inside the db container against the maintenance database.
+psql_admin() {
+    "${COMPOSE[@]}" exec -T "$DB_SERVICE" \
+        psql -v ON_ERROR_STOP=1 -U "$LOCAL_DB_USER" -d postgres "$@"
+}
+
+# ── Dump the production database ───────────────────────────────────────────
+echo "==> Dumping production database..."
+DUMP_ARGS=(--no-owner --no-privileges --clean --if-exists)
+if $SCHEMA_ONLY; then
+    DUMP_ARGS+=(--schema-only)
+    echo "    (schema only — no data)"
+fi
+
+# pg_dump runs in a throwaway postgres:17 container so the client version
+# matches the local server. set -e aborts the script on any failure.
+docker run --rm "$PG_IMAGE" pg_dump "${DUMP_ARGS[@]}" "$DUMP_URL" > "$DUMP_FILE"
+
+if [[ ! -s "$DUMP_FILE" ]]; then
+    echo "ERROR: dump file is empty — aborting before touching the local DB." >&2
+    exit 1
+fi
+echo "    Dump complete: $(du -h "$DUMP_FILE" | cut -f1)"
+
+# ── Recreate the local database (clean slate) ─────────────────────────────
+echo "==> Recreating the local '$LOCAL_DB_NAME' database..."
+psql_admin -c "
+    SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+    WHERE datname = '$LOCAL_DB_NAME' AND pid <> pg_backend_pid();
+" >/dev/null
+psql_admin -c "DROP DATABASE IF EXISTS $LOCAL_DB_NAME;" >/dev/null
+psql_admin -c "CREATE DATABASE $LOCAL_DB_NAME OWNER $LOCAL_DB_USER;" >/dev/null
+
+# ── Restore into the local database ───────────────────────────────────────
+echo "==> Restoring into the local database..."
+# ON_ERROR_STOP + --single-transaction: any error aborts the whole restore
+# and leaves the database empty rather than half-populated.
+"${COMPOSE[@]}" exec -T "$DB_SERVICE" \
+    psql -v ON_ERROR_STOP=1 --single-transaction \
+    -U "$LOCAL_DB_USER" -d "$LOCAL_DB_NAME" < "$DUMP_FILE"
+
+echo "    Restore complete."
+echo ""
+echo "==> Clone finished. NEXT STEP — verify it before cutting over:"
+echo "    ./scripts/verify-db-clone.sh"
+echo ""

--- a/scripts/verify-db-clone.sh
+++ b/scripts/verify-db-clone.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# verify-db-clone.sh — Prove that the local clone matches production.
+#
+# Compares the Supabase production database (source) against the local
+# Dockerized PostgreSQL (target) and reports any difference. Run this
+# after scripts/migrate-prod-db.sh and BEFORE cutting over — the cutover
+# should proceed only if this script exits 0.
+#
+# Checks:
+#   1. Connectivity to both databases
+#   2. Alembic schema version matches
+#   3. Same set of tables in both
+#   4. Per-table row count matches
+#   5. Per-table content checksum matches (order-independent md5 of rows)
+#   6. Sequence last_value matches (so the next INSERT will not collide)
+#
+# Usage:
+#   ./scripts/verify-db-clone.sh                 # source from Doppler prod
+#   ./scripts/verify-db-clone.sh <source_url>    # explicit source URL
+#
+# Prerequisites:
+#   - The podcast-rag-db container is running
+#   - Doppler CLI configured with access to the `prod` config
+#   - Docker available (the postgres:17 image is used as a psql client)
+#
+set -euo pipefail
+
+# ── Resolve repo root so `docker compose` finds docker-compose.yml ─────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$REPO_ROOT"
+
+DB_SERVICE="podcast-rag-db"
+LOCAL_DB_USER="podcast_rag"
+LOCAL_DB_NAME="podcast_rag"
+PG_IMAGE="postgres:17"
+COMPOSE=(docker compose)
+
+# ── Resolve the production (source) DATABASE_URL ──────────────────────────
+SRC_URL="${1:-}"
+if [[ -z "$SRC_URL" ]]; then
+    echo "==> Fetching production DATABASE_URL from Doppler (config: prod)..."
+    SRC_URL="$(doppler secrets get DATABASE_URL --plain --config prod 2>/dev/null || true)"
+fi
+if [[ -z "$SRC_URL" ]]; then
+    echo "ERROR: no source DATABASE_URL (pass one as an argument or configure Doppler)." >&2
+    exit 1
+fi
+# Use session mode (5432) for consistency with the dump.
+SRC_URL="${SRC_URL//:6543/:5432}"
+
+# ── Query helpers (-t tuples only, -A unaligned, -q quiet) ────────────────
+src_q() { docker run --rm "$PG_IMAGE" psql "$SRC_URL" -tAqc "$1"; }
+tgt_q() {
+    "${COMPOSE[@]}" exec -T "$DB_SERVICE" \
+        psql -U "$LOCAL_DB_USER" -d "$LOCAL_DB_NAME" -tAqc "$1"
+}
+
+FAIL=0
+note_fail() { FAIL=1; echo "    ✗ MISMATCH: $1" >&2; }
+
+# ── 1. Connectivity ───────────────────────────────────────────────────────
+echo "==> Checking connectivity..."
+[[ "$(src_q 'SELECT 1;')" == "1" ]] || { echo "ERROR: cannot query source." >&2; exit 1; }
+[[ "$(tgt_q 'SELECT 1;')" == "1" ]] || { echo "ERROR: cannot query target." >&2; exit 1; }
+echo "    Both databases reachable."
+
+# ── 2. Alembic schema version ─────────────────────────────────────────────
+echo "==> Comparing Alembic schema version..."
+AV_SRC="$(src_q 'SELECT version_num FROM alembic_version;')"
+AV_TGT="$(tgt_q 'SELECT version_num FROM alembic_version;')"
+if [[ "$AV_SRC" == "$AV_TGT" && -n "$AV_SRC" ]]; then
+    echo "    OK — both at $AV_SRC"
+else
+    note_fail "alembic_version: source='$AV_SRC' target='$AV_TGT'"
+fi
+
+# ── 3. Table inventory ────────────────────────────────────────────────────
+echo "==> Comparing table inventory..."
+LIST_SQL="SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename;"
+TABLES_SRC="$(src_q "$LIST_SQL")"
+TABLES_TGT="$(tgt_q "$LIST_SQL")"
+if [[ "$TABLES_SRC" == "$TABLES_TGT" ]]; then
+    echo "    OK — $(echo "$TABLES_TGT" | grep -c . || true) tables match"
+else
+    note_fail "table list differs:"
+    diff <(echo "$TABLES_SRC") <(echo "$TABLES_TGT") >&2 || true
+fi
+
+# ── 4 & 5. Per-table row count + content checksum ─────────────────────────
+echo "==> Comparing row counts and content checksums..."
+printf '    %-34s %10s %10s  %s\n' "TABLE" "SRC ROWS" "TGT ROWS" "STATUS"
+printf '    %-34s %10s %10s  %s\n' "----------------------------------" "--------" "--------" "------"
+
+# Order-independent: hash each row, sort the hashes, hash the concatenation.
+row_query() {
+    echo "SELECT count(*), coalesce(md5(string_agg(rh, '' ORDER BY rh)), 'EMPTY') \
+FROM (SELECT md5(x::text) AS rh FROM public.\"$1\" x) s;"
+}
+
+while IFS= read -r tbl; do
+    [[ -z "$tbl" ]] && continue
+    q="$(row_query "$tbl")"
+    src_res="$(src_q "$q")"; tgt_res="$(tgt_q "$q")"
+    src_cnt="${src_res%%|*}"; src_sum="${src_res##*|}"
+    tgt_cnt="${tgt_res%%|*}"; tgt_sum="${tgt_res##*|}"
+    if [[ "$src_cnt" == "$tgt_cnt" && "$src_sum" == "$tgt_sum" ]]; then
+        status="OK"
+    else
+        status="MISMATCH"; FAIL=1
+    fi
+    printf '    %-34s %10s %10s  %s\n' "$tbl" "$src_cnt" "$tgt_cnt" "$status"
+done <<< "$TABLES_TGT"
+
+# ── 6. Sequences ──────────────────────────────────────────────────────────
+echo "==> Comparing sequence values..."
+SEQ_SQL="SELECT schemaname||'.'||sequencename||'='||coalesce(last_value::text,'NULL') \
+FROM pg_sequences WHERE schemaname='public' ORDER BY 1;"
+SEQ_SRC="$(src_q "$SEQ_SQL")"
+SEQ_TGT="$(tgt_q "$SEQ_SQL")"
+if [[ "$SEQ_SRC" == "$SEQ_TGT" ]]; then
+    echo "    OK — $(echo "$SEQ_TGT" | grep -c . || true) sequences match"
+else
+    note_fail "sequence values differ:"
+    diff <(echo "$SEQ_SRC") <(echo "$SEQ_TGT") >&2 || true
+fi
+
+# ── Verdict ───────────────────────────────────────────────────────────────
+echo ""
+if [[ "$FAIL" -eq 0 ]]; then
+    echo "==> ✓ VERIFICATION PASSED — the clone matches production."
+    exit 0
+else
+    echo "==> ✗ VERIFICATION FAILED — do NOT cut over. Investigate the mismatches above." >&2
+    exit 1
+fi

--- a/scripts/verify-db-clone.sh
+++ b/scripts/verify-db-clone.sh
@@ -51,7 +51,11 @@ SRC_URL="${SRC_URL//:6543/:5432}"
 # ── Query helpers (-t tuples only, -A unaligned, -q quiet) ────────────────
 src_q() { docker run --rm "$PG_IMAGE" psql "$SRC_URL" -tAqc "$1"; }
 tgt_q() {
-    docker exec -i "$DB_CONTAINER" \
+    # NOTE: no -i. This function is called inside a `while read … done <<<`
+    # loop, and `docker exec -i` would inherit and consume the remaining
+    # heredoc on each call, silently skipping every table after the first.
+    # We're passing SQL via -c, so we don't need stdin here.
+    docker exec "$DB_CONTAINER" \
         psql -U "$LOCAL_DB_USER" -d "$LOCAL_DB_NAME" -tAqc "$1"
 }
 

--- a/scripts/verify-db-clone.sh
+++ b/scripts/verify-db-clone.sh
@@ -26,16 +26,14 @@
 #
 set -euo pipefail
 
-# ── Resolve repo root so `docker compose` finds docker-compose.yml ─────────
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-cd "$REPO_ROOT"
+# Compose-project-agnostic: queries the local DB via raw `docker exec`
+# against the fixed container name, so it works regardless of which
+# compose stack (this repo or homelab/) owns the container.
 
-DB_SERVICE="podcast-rag-db"
+DB_CONTAINER="podcast-rag-db"
 LOCAL_DB_USER="podcast_rag"
 LOCAL_DB_NAME="podcast_rag"
 PG_IMAGE="postgres:17"
-COMPOSE=(docker compose)
 
 # ── Resolve the production (source) DATABASE_URL ──────────────────────────
 SRC_URL="${1:-}"
@@ -53,7 +51,7 @@ SRC_URL="${SRC_URL//:6543/:5432}"
 # ── Query helpers (-t tuples only, -A unaligned, -q quiet) ────────────────
 src_q() { docker run --rm "$PG_IMAGE" psql "$SRC_URL" -tAqc "$1"; }
 tgt_q() {
-    "${COMPOSE[@]}" exec -T "$DB_SERVICE" \
+    docker exec -i "$DB_CONTAINER" \
         psql -U "$LOCAL_DB_USER" -d "$LOCAL_DB_NAME" -tAqc "$1"
 }
 


### PR DESCRIPTION
## Summary

Moves the **database** off Supabase to a local PostgreSQL on **bubba**, and prepares to retire the Cloud Run frontend in favor of a Cloudflare Tunnel to the existing `podcast-rag-web` container on bubba.

No `src/` application code changes — the app is already DB-host-agnostic via `src/db/factory.py`; only the `DATABASE_URL` value changes (in Doppler, at cutover time).

> **Compose changes for bubba live in [allenhutchison/homelab#1](https://github.com/allenhutchison/homelab/pull/1).** On bubba the runtime stack is managed by `~/src/homelab` (composed via `nodes/bubba.sh`), not by this repo's `docker-compose.yml`, so the `podcast-rag-db` + `cloudflared` services land in the homelab repo. This PR is the supporting pieces that belong in the podcast-rag repo: the migration scripts, the runbook, and the Dockerfile.web change.

## Changes

- **`Dockerfile.web`** — uvicorn now passes `--proxy-headers` and ships with `UVICORN_FORWARDED_ALLOW_IPS=*` as an override-friendly env var. Needed behind Cloudflare Tunnel so OAuth redirect URIs are `https://`, Secure cookies set, and the rate limiter sees real client IPs. Harmless on Cloud Run.
- **`scripts/migrate-prod-db.sh`** — one-time production clone. `pg_dump` Supabase (rewriting pooler port `6543`→`5432`), drop/recreate the local `podcast_rag` database, restore with `ON_ERROR_STOP=1 --single-transaction`. Fails loudly.
- **`scripts/verify-db-clone.sh`** — the cutover gate. Compares Alembic version, table inventory, per-table row counts, order-independent content checksums, and sequence values; exits non-zero on any mismatch.
- **`scripts/backup-db.sh`** — scheduled local `pg_dump` with retention, replaces Supabase's managed backups.
- **`docs/deploy-vps.md`** — 5-phase deployment + cutover runbook for bubba, pointing at the homelab compose stack.

All three scripts use raw `docker exec podcast-rag-db ...` against the fixed container name, so they're compose-project-agnostic and run from `~/src/podcast-rag/` regardless of which compose stack owns the container.

## Migration approach

- **Cutover:** short maintenance window — stop Cloud Run, freeze pipeline writes, final clone, verify, flip `DATABASE_URL` in Doppler, restart, switch tunnel DNS.
- **TLS/ingress:** Cloudflare Tunnel (outbound-only, no inbound ports). Configured in the Zero Trust dashboard for the tunnel that owns `TUNNEL_TOKEN`.
- **Rollback:** Supabase kept as a point-in-time standby for ~2 weeks; nothing is written to the local DB until after verification passes.

## Out of scope (deferred to Phase 5, after Cloud Run is retired)

Deleting `cloudbuild.yaml` and updating `AGENTS.md` / `docs/deploy-quick-start.md` / `docs/WEB_ARCHITECTURE.md` to drop the Cloud Run references — tracked in the runbook.

## Test plan

- [x] `bash -n` passes on all three scripts.
- [x] [homelab#1](https://github.com/allenhutchison/homelab/pull/1)'s `docker compose config` resolves cleanly with the new podcast-rag-db + cloudflared services merged into the bubba stack.
- [ ] Phase 1: bring up `podcast-rag-db` via the homelab stack on bubba.
- [ ] Phase 2: rehearse `migrate-prod-db.sh` → `verify-db-clone.sh` against Supabase. Must exit 0 before this PR or homelab#1 merges.
- [ ] Phase 3: stand up cloudflared, smoke-test from a temporary hostname.
- [ ] Phase 4 (maintenance window): final clone, verify, flip `DATABASE_URL`, restart, switch DNS, smoke-test prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive VPS deployment guide with procedures for infrastructure migration, prerequisites, and phased production cutover.

* **New Features**
  * Added database backup script with automated retention management.
  * Added production database cloning script for migration scenarios.
  * Added database verification script to validate clones against source.

* **Infrastructure**
  * Enhanced web service configuration with improved proxy header handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/podcast-rag/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->