### PR TITLE
chore(config): drop dead WEB_PORT and SUPABASE_* attrs

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -91,7 +91,6 @@ class Config:
         self.WEB_MAX_CONVERSATION_TOKENS = int(os.getenv("MAX_CONVERSATION_TOKENS", "200000"))
         self.WEB_STREAMING_DELAY = float(os.getenv("STREAMING_DELAY", "0.05"))
         self.WEB_RATE_LIMIT = os.getenv("RATE_LIMIT", "10/minute")
-        self.WEB_PORT = int(os.getenv("PORT", "8080"))
 
         # Web app base URL (used for email links and OAuth redirect)
         web_base_url = os.getenv("WEB_BASE_URL", "")
@@ -136,15 +135,10 @@ class Config:
         self.DATABASE_URL = os.getenv(
             "DATABASE_URL", "sqlite:///./podcast_rag.db"
         )
-        self.DB_POOL_SIZE = int(os.getenv("DB_POOL_SIZE", "3"))  # Supabase-optimized
-        self.DB_MAX_OVERFLOW = int(os.getenv("DB_MAX_OVERFLOW", "2"))  # Supabase-optimized
+        self.DB_POOL_SIZE = int(os.getenv("DB_POOL_SIZE", "3"))
+        self.DB_MAX_OVERFLOW = int(os.getenv("DB_MAX_OVERFLOW", "2"))
         self.DB_POOL_PRE_PING = os.getenv("DB_POOL_PRE_PING", "true").lower() == "true"
         self.DB_ECHO = os.getenv("DB_ECHO", "false").lower() == "true"
-
-        # Supabase configuration (for future features)
-        self.SUPABASE_URL = os.getenv("SUPABASE_URL", "")
-        self.SUPABASE_ANON_KEY = os.getenv("SUPABASE_ANON_KEY", "")
-        self.SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
 
         # Podcast download configuration
         self.PODCAST_MAX_CONCURRENT_DOWNLOADS = int(

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -174,7 +174,6 @@ class TestConfiguration:
         assert hasattr(config, "WEB_MAX_CONVERSATION_TOKENS")
         assert hasattr(config, "WEB_STREAMING_DELAY")
         assert hasattr(config, "WEB_RATE_LIMIT")
-        assert hasattr(config, "WEB_PORT")
 
     def test_default_config_values(self):
         """Test that default configuration values are set."""
@@ -182,7 +181,6 @@ class TestConfiguration:
         assert config.WEB_MAX_CONVERSATION_TOKENS == 200000
         assert config.WEB_STREAMING_DELAY == 0.05
         assert config.WEB_RATE_LIMIT == "10/minute"
-        assert config.WEB_PORT == 8080
 
 
 class TestDopplerEnvLoading:


### PR DESCRIPTION
## Summary

Drop four dead `Config` attributes left over from the Cloud Run / Supabase era. Companion to the Doppler key cleanup happening in the dashboard.

| Attribute | Where assigned | Consumers |
|---|---|---|
| `WEB_PORT` | `config.py:94` | none (web port is hardcoded `8080` in `Dockerfile.web` CMD + re-set as env in homelab compose) |
| `SUPABASE_URL` | `config.py:145` | none |
| `SUPABASE_ANON_KEY` | `config.py:146` | none |
| `SUPABASE_SERVICE_ROLE_KEY` | `config.py:147` | none |

Also dropped the misleading `# Supabase-optimized` comments next to `DB_POOL_SIZE` / `DB_MAX_OVERFLOW`. The tuning values themselves (3 / 2) still work fine for the local PG instance — only the comment was stale.

Companion test cleanup in `tests/test_web_app.py`: remove the two `WEB_PORT` assertions.

## Out of scope (handled in Doppler dashboard)

These Doppler keys are being removed separately from the `prod` config (zero references in `src/`, `alembic/`, `scripts/`, `tests/`):

- `PORT` (the env var that fed `WEB_PORT`)
- `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
- `DOPPLER_CONFIG`, `DOPPLER_ENVIRONMENT`, `DOPPLER_PROJECT` (auto-injected by `doppler run --`)
- `WORKFLOW_RUN_INTERVAL_SECONDS` (value 900, no references)

## Test plan

- [x] `uv run pytest -q` — 1117 passed, 8 skipped, 0 failed.
- [x] `grep -rIn "WEB_PORT\|SUPABASE_URL\|SUPABASE_ANON_KEY\|SUPABASE_SERVICE_ROLE_KEY" src/ alembic/ scripts/` returns nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated web server configuration handling. The `PORT` environment variable no longer configures the web server port. Database configuration settings remain functional as previously configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/allenhutchison/podcast-rag/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->