### PR TITLE
fix(ci): drop broken Microsoft apt repos before apt-get update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,12 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          # The GitHub-hosted runner image preconfigures Microsoft apt repos
+          # (azure-cli, prod) that intermittently return 403 and break
+          # `apt-get update`. We don't need them to install ffmpeg, so remove
+          # them first to keep CI resilient to that upstream breakage.
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update
           sudo apt-get install -y ffmpeg
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,13 @@ jobs:
         run: |
           # The GitHub-hosted runner image preconfigures Microsoft apt repos
           # (azure-cli, prod) that intermittently return 403 and break
-          # `apt-get update`. We don't need them to install ffmpeg, so remove
-          # them first to keep CI resilient to that upstream breakage.
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list \
-                     /etc/apt/sources.list.d/azure-cli.list
+          # `apt-get update`. We don't need them to install ffmpeg, so drop any
+          # apt source referencing packages.microsoft.com first. Match both the
+          # legacy .list and newer deb822 .sources formats so this stays
+          # resilient as the runner image changes.
+          sudo find /etc/apt/sources.list.d -type f \
+            \( -name '*.list' -o -name '*.sources' \) \
+            -exec grep -lq 'packages\.microsoft\.com' {} \; -print -delete || true
           sudo apt-get update
           sudo apt-get install -y ffmpeg
 


### PR DESCRIPTION
## Problem

CI on every PR/push is currently failing (e.g. #158) at the **Install system dependencies** step in `.github/workflows/test.yml`, on `sudo apt-get update`:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  403  Forbidden
E: The repository 'https://packages.microsoft.com/repos/azure-cli noble InRelease' is no longer signed.
E: Failed to fetch https://packages.microsoft.com/ubuntu/24.04/prod/dists/noble/InRelease  403  Forbidden
##[error]Process completed with exit code 100.
```

The GitHub-hosted `ubuntu-24.04` runner image preconfigures Microsoft apt repositories (`azure-cli` and `prod`) that are currently returning **403 Forbidden**. Because the step runs under `bash -e`, `apt-get update` exiting non-zero kills the step before `ffmpeg` is installed or any tests run, and the matrix fail-fast then cancels the sibling job. This is an environmental/runner-image issue, unrelated to any code or dependency change.

## Fix

Remove the Microsoft apt repos (not needed to install `ffmpeg`) before running `apt-get update`, so it only hits the working Ubuntu mirrors.

## Impact

Unblocks CI for all open PRs, including the Dependabot bump in #158.

https://claude.ai/code/session_01Y161jQmTJ28S2wfdf2x45t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y161jQmTJ28S2wfdf2x45t)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI pipeline stability by removing problematic package source entries that intermittently caused authorization failures during environment setup. This prevents sporadic test setup errors and leads to more consistent installation and test runs across builds, without changing the subsequent install, test, or coverage upload steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->