### PR TITLE
fix(email): use WEB_BASE_URL for "Listen to this briefing" link

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -89,9 +89,6 @@ class Config:
             raise ValueError(
                 f"BRIEFING_AUDIO_RETENTION_DAYS must be non-negative, got {self.BRIEFING_AUDIO_RETENTION_DAYS}"
             )
-        # Base URL for email links (e.g. "Listen to this briefing")
-        self.APP_BASE_URL = os.getenv("APP_BASE_URL", "https://podcast-rag.feed")
-
         # Gemini File Search configuration
         self.GEMINI_FILE_SEARCH_STORE_NAME = os.getenv("GEMINI_FILE_SEARCH_STORE_NAME", "podcast-transcripts")
 

--- a/src/services/email_renderer.py
+++ b/src/services/email_renderer.py
@@ -160,11 +160,14 @@ def _render_briefing_html(briefing: dict) -> str:
             f'{escape_html(connection)}</p></div>'
         )
 
-    # "Listen to this briefing" link — opens web player which generates audio on demand
+    # "Listen to this briefing" link — opens web player which generates audio on demand.
+    # Uses WEB_BASE_URL (the public app URL, same as other email links) so the link
+    # points at the real service. Skip the link entirely if no base URL is configured,
+    # since a relative URL is useless in an email.
     briefing_id = briefing.get("id")
     audio_link_html = ""
-    if briefing_id:
-        base_url = _config.APP_BASE_URL if _config else "https://localhost:8080"
+    base_url = _get_config().WEB_BASE_URL.rstrip("/")
+    if briefing_id and base_url:
         play_url = f"{base_url}/feed.html?play={quote(str(briefing_id), safe='')}"
         audio_link_html = (
             f'<div style="margin-top: 16px;">'

--- a/tests/test_email_content.py
+++ b/tests/test_email_content.py
@@ -427,6 +427,38 @@ class TestBriefingRenderingHtml:
         assert "barely scratching" in html
 
 
+class TestBriefingListenLink:
+    """The 'Listen to this briefing' link must point at the real service URL."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_config(self, monkeypatch):
+        """Force email_renderer to re-read config from the patched environment."""
+        import src.services.email_renderer as email_renderer
+
+        monkeypatch.setattr(email_renderer, "_config", None)
+        yield
+        monkeypatch.setattr(email_renderer, "_config", None)
+
+    def test_listen_link_uses_web_base_url(self, monkeypatch):
+        """Link is built from WEB_BASE_URL, not a hard-coded placeholder domain."""
+        monkeypatch.setenv("WEB_BASE_URL", "https://podcasts.example.com")
+        briefing = {**SAMPLE_BRIEFING, "id": "abc-123"}
+        html = render_digest_html("User", [MockEpisode()], briefing=briefing)
+
+        assert "https://podcasts.example.com/feed.html?play=abc-123" in html
+        assert "Listen to this briefing" in html
+        # The old bogus default must never leak into an email.
+        assert "podcast-rag.feed" not in html
+
+    def test_listen_link_omitted_without_base_url(self, monkeypatch):
+        """With no WEB_BASE_URL configured, skip the link rather than emit a broken one."""
+        monkeypatch.delenv("WEB_BASE_URL", raising=False)
+        briefing = {**SAMPLE_BRIEFING, "id": "abc-123"}
+        html = render_digest_html("User", [MockEpisode()], briefing=briefing)
+
+        assert "Listen to this briefing" not in html
+
+
 class TestBriefingRenderingText:
     """Tests for briefing section in plain text digest."""
 


### PR DESCRIPTION
## Problem

The **▶ Listen to this briefing** link in daily briefing emails pointed at the wrong URL. It was built from a stray, undocumented `APP_BASE_URL` env var that was never set in production, so it fell back to its hard-coded default `https://podcast-rag.feed` — a non-existent domain. Clicking the link in the email went nowhere.

## Root cause

The rest of the app (OAuth, and the episode links in the same email via `build_episode_url`) uses the documented `WEB_BASE_URL` var, set to `https://podcasts.hutchison.org` in production. The briefing link was the lone outlier reading a different, unset variable.

## Fix

- Build the link from `WEB_BASE_URL`, matching every other email link → resolves to `https://podcasts.hutchison.org/feed.html?play=<id>`.
- Omit the link entirely when no base URL is configured, instead of emitting a broken placeholder/relative URL.
- Remove the now-unused `APP_BASE_URL` config entry.
- Add `TestBriefingListenLink` regression tests: the link uses `WEB_BASE_URL`, and `podcast-rag.feed` never leaks into an email.

`configuration.md` already documents `WEB_BASE_URL` as "used for email links," so the code now matches the docs; no docs change needed. Confirmed `WEB_BASE_URL` is set correctly in production Doppler.

## Testing

`uv run poe test` → **1171 passed, 8 skipped**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated email digest links to correctly use the configured web base URL for "Listen to this briefing" functionality
  * Prevented broken placeholder URLs from appearing in emails when base URL configuration is missing, improving email reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->