### PR TITLE
fix(tts): stop briefing audio from fading and accelerating over its length

### DIFF
--- a/src/services/briefing_generator.py
+++ b/src/services/briefing_generator.py
@@ -389,8 +389,11 @@ mini-analysis. Use a transition phrase between episodes.
 (just podcast name + episode title, no analysis).
 - Close with the connection_insight (if present) as a reflective sign-off, \
 then a brief outro.
-- Use audio tags in square brackets for narration control where natural, \
-e.g. [pause], [emphasis], [quieter], [faster]. Use sparingly.
+- Do NOT include any bracketed audio tags or stage directions (e.g. [pause], \
+[emphasis], [quieter], [faster]). The TTS model voices the delivery itself; \
+inline tags get read aloud or cause the pace and volume to drift over the \
+course of the audio. Convey pacing and emphasis through word choice and \
+sentence structure only.
 - Do NOT include section headers, markdown, or formatting. Output plain \
 spoken text only.
 

--- a/src/services/tts.py
+++ b/src/services/tts.py
@@ -22,6 +22,16 @@ logger = logging.getLogger(__name__)
 # MIME type for the output MP3
 AUDIO_MIME_TYPE = "audio/mpeg"
 
+# Global delivery instruction prepended to the script. Gemini TTS controls
+# style/pace/volume from natural-language guidance in the prompt; steering it
+# once up front keeps delivery uniform start-to-finish and avoids the pace/
+# volume drift that inline bracket tags cause.
+_TTS_STYLE_PREFIX = (
+    "Read the following daily podcast briefing aloud in a warm, engaging host "
+    "voice, at a calm and consistent pace and volume from start to finish. "
+    "Do not speed up, slow down, or get quieter as you go.\n\n"
+)
+
 # Retry config for transient Gemini API errors
 _MAX_RETRIES = 3
 _BASE_DELAY = 1.0
@@ -79,7 +89,7 @@ def render_tts_to_mp3(
         response = _retry_tts_call(
             client,
             model=config.GEMINI_TTS_MODEL,
-            contents=script,
+            contents=_TTS_STYLE_PREFIX + script,
             config=types.GenerateContentConfig(
                 response_modalities=["AUDIO"],
                 speech_config=types.SpeechConfig(
@@ -138,6 +148,9 @@ def _pcm_to_mp3(pcm_bytes: bytes, sample_rate: int) -> bytes | None:
                 "-ar", str(sample_rate),
                 "-ac", "1",
                 "-i", "pipe:0",
+                # Normalize loudness (EBU R128) so volume stays consistent
+                # across the whole briefing regardless of TTS delivery.
+                "-af", "loudnorm=I=-16:TP=-1.5:LRA=11",
                 "-codec:a", "libmp3lame",
                 "-b:a", "64k",
                 "-f", "mp3",

--- a/src/services/tts.py
+++ b/src/services/tts.py
@@ -83,6 +83,12 @@ def render_tts_to_mp3(
     Returns:
         (mp3_bytes, duration_seconds). Both None on failure.
     """
+    if not script.strip():
+        # The style prefix is always non-empty, so a blank script would still
+        # build a valid prompt and make the model speak the instruction itself.
+        logger.error("Refusing to render empty TTS script")
+        return None, None
+
     try:
         client = genai.Client(api_key=config.GEMINI_API_KEY)
 

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -69,11 +69,23 @@ class TestRenderTtsToMp3:
         render_tts_to_mp3("Here is the briefing.", mock_config)
 
         contents = mock_client.models.generate_content.call_args.kwargs["contents"]
+        ffmpeg_cmd = mock_subprocess.call_args_list[0].args[0]
         # A single up-front delivery instruction keeps pace/volume uniform and
         # the original script still follows it verbatim.
         assert contents.startswith("Read the following")
         assert "consistent pace and volume" in contents
         assert contents.endswith("Here is the briefing.")
+        # The loudnorm safety net must stay in the ffmpeg invocation.
+        assert "-af" in ffmpeg_cmd
+        assert "loudnorm=I=-16:TP=-1.5:LRA=11" in ffmpeg_cmd
+
+    @patch("src.services.tts.genai.Client")
+    def test_blank_script_returns_none_without_api_call(self, mock_client_cls, mock_config):
+        # A whitespace-only script must fail fast, not synthesize the prefix.
+        mp3, duration = render_tts_to_mp3("   \n  ", mock_config)
+        assert mp3 is None
+        assert duration is None
+        mock_client_cls.assert_not_called()
 
     @patch("src.services.tts.genai.Client")
     def test_api_failure_returns_none(self, mock_client_cls, mock_config):

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -51,6 +51,31 @@ class TestRenderTtsToMp3:
         assert mock_subprocess.call_args_list[0].kwargs["input"] == pcm_data
 
     @patch("src.services.tts.genai.Client")
+    @patch("src.services.tts.subprocess.run")
+    def test_prepends_style_prefix(self, mock_subprocess, mock_client_cls, mock_config):
+        mock_part = MagicMock()
+        mock_part.inline_data.data = b"\x00\x01" * 100
+        mock_candidate = MagicMock()
+        mock_candidate.content.parts = [mock_part]
+        mock_response = MagicMock()
+        mock_response.candidates = [mock_candidate]
+        mock_client = MagicMock()
+        mock_client.models.generate_content.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        ffmpeg_result = MagicMock(returncode=0, stdout=b"fake mp3", stderr=b"")
+        mock_subprocess.side_effect = [ffmpeg_result, MagicMock(stdout=b"180.5\n")]
+
+        render_tts_to_mp3("Here is the briefing.", mock_config)
+
+        contents = mock_client.models.generate_content.call_args.kwargs["contents"]
+        # A single up-front delivery instruction keeps pace/volume uniform and
+        # the original script still follows it verbatim.
+        assert contents.startswith("Read the following")
+        assert "consistent pace and volume" in contents
+        assert contents.endswith("Here is the briefing.")
+
+    @patch("src.services.tts.genai.Client")
     def test_api_failure_returns_none(self, mock_client_cls, mock_config):
         mock_client = MagicMock()
         mock_client.models.generate_content.side_effect = RuntimeError("API error")


### PR DESCRIPTION
## Problem

Two audio bugs in the daily briefing MP3, reported from listening to a real generated file:

1. **The TTS voice audibly says "pause"** between stories.
2. **The audio progressively gets faster, quieter, and higher-pitched** as the briefing goes on.

## Root cause

The audio-script prompt (`briefing_generator.py`) told Gemini to insert bracket "audio tags" — `[pause]`, `[emphasis]`, `[quieter]`, `[faster]` — and `tts.py` renders the whole script in a single pass to `gemini-3.1-flash-tts-preview` with no other delivery control.

- `[pause]`/`[emphasis]` aren't canonical Gemini TTS tags, so the model sometimes voices them **literally**.
- `[quieter]` and `[faster]` are **persistent** style directives: in one long render the model carries the style forward, so sprinkled tags **compound** into a steady downward/faster ramp.

Measured on a real briefing MP3 (per-30s windows):

| Window | Mean volume |
|--------|-------------|
| 0–30s | −21.8 dB |
| 150–180s | −25.7 dB |
| 300–330s | −36.8 dB |

~15 dB monotonic loudness fade (≈5× perceived), accelerating in the back half — the fingerprint of compounding `[quieter]` directives.

## Fix

- **`briefing_generator.py`** — replace the "use audio tags" instruction with an explicit rule to emit **no** bracketed tags; convey pacing through word choice instead.
- **`tts.py`** — prepend a single global natural-language delivery instruction (the documented, reliable way to steer Gemini TTS) so pace/volume stay uniform start-to-finish.
- **`tts.py`** — add ffmpeg `loudnorm` (EBU R128) as a volume-consistency safety net.
- **`tests/test_tts.py`** — new test locking in the style-prefix behavior.

## Notes

- This only affects **newly generated** briefings; existing stored MP3s are unchanged.
- The prompt change is the real cure; `loudnorm` is belt-and-suspenders.

## Test plan

- `uv run poe test` → 1172 passed, 8 skipped.
- CodeRabbit (`coderabbit review --agent`) → 0 findings.
- End-to-end audio verification will happen on the next scheduled briefing after deploy.

https://claude.ai/code/session_01Y2DrNwR7bG82oqUHrmQvtX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced audio generation instructions to keep narration flowing consistently without bracketed stage directions.
  * Added system-style guidance to the text-to-speech request to improve delivery consistency.
  * Improved spoken output by applying loudness normalization to generated MP3s.

* **Bug Fixes**
  * Prevented audio rendering when the input script is empty/whitespace, returning a safe `(None, None)` result.

* **Tests**
  * Added tests verifying the updated speech request payload and loudness normalization filter, plus coverage for blank-script short-circuiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->