### PR TITLE
feat(transcription): add Scribe compatibility backend

### DIFF
--- a/alembic/versions/20260822_1200_a7c8d9e0f1a2_add_external_transcript_fields.py
+++ b/alembic/versions/20260822_1200_a7c8d9e0f1a2_add_external_transcript_fields.py
@@ -1,0 +1,32 @@
+"""add external transcript fields
+
+Revision ID: a7c8d9e0f1a2
+Revises: dd7777d4445b
+Create Date: 2026-08-22 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a7c8d9e0f1a2"
+down_revision: str | None = "dd7777d4445b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("episodes", sa.Column("transcript_provider", sa.String(32), nullable=True))
+    op.add_column("episodes", sa.Column("transcript_external_id", sa.String(64), nullable=True))
+    op.add_column("episodes", sa.Column("transcript_model", sa.String(64), nullable=True))
+    op.add_column("episodes", sa.Column("transcript_language", sa.String(16), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("episodes", "transcript_language")
+    op.drop_column("episodes", "transcript_model")
+    op.drop_column("episodes", "transcript_external_id")
+    op.drop_column("episodes", "transcript_provider")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,10 +49,11 @@ These must be set for the application to function:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `TRANSCRIPTION_BACKEND` | `local` | `local` for the embedded faster-whisper worker or `scribe` for the shared service |
-| `SCRIBE_BASE_URL` | `http://scribe:8000` | Private base URL of the Scribe API |
+| `SCRIBE_BASE_URL` | `https://scribe.vycari.ai` | HTTPS base URL of the Scribe API |
 | `SCRIBE_API_TOKEN` | — | Bearer token for the `podcast-rag` Scribe consumer; required for the Scribe backend |
 | `SCRIBE_REQUEST_TIMEOUT` | `30` | HTTP request timeout in seconds; queued work is polled on later pipeline ticks |
 | `SCRIBE_LANGUAGE` | `en` | Language hint sent to Scribe. Set to an empty value to use auto-detection |
+| `SCRIBE_ALLOW_INSECURE_HTTP` | `false` | Explicitly permit `http://` only on a trusted local development/private network |
 
 Keep `TRANSCRIPTION_BACKEND=local` until existing transcripts have been seeded
 and verified. The Scribe compatibility worker continues storing transcript text

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,23 @@ These must be set for the application to function:
 
 **Note:** The `medium` model offers the best balance of speed and accuracy. Use `large-v3` for maximum accuracy (requires ~10GB VRAM).
 
+## Transcription Backend and Scribe
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRANSCRIPTION_BACKEND` | `local` | `local` for the embedded faster-whisper worker or `scribe` for the shared service |
+| `SCRIBE_BASE_URL` | `http://scribe:8000` | Private base URL of the Scribe API |
+| `SCRIBE_API_TOKEN` | — | Bearer token for the `podcast-rag` Scribe consumer; required for the Scribe backend |
+| `SCRIBE_REQUEST_TIMEOUT` | `30` | HTTP request timeout in seconds; queued work is polled on later pipeline ticks |
+| `SCRIBE_LANGUAGE` | `en` | Language hint sent to Scribe. Set to an empty value to use auto-detection |
+
+Keep `TRANSCRIPTION_BACKEND=local` until existing transcripts have been seeded
+and verified. The Scribe compatibility worker continues storing transcript text
+in podcast-rag while the migration is being validated. Scribe's cache is shared
+with Pepper: completed rows are reusable across both consumers, and a terminal
+`failed` result remains immutable rather than being retried by one consumer
+behind the other's back.
+
 ## Database
 
 | Variable | Default | Description |

--- a/docs/scribe-migration.md
+++ b/docs/scribe-migration.md
@@ -89,10 +89,11 @@ TRANSCRIPTION_BACKEND=scribe
 SCRIBE_API_TOKEN=<podcast-rag consumer token>
 ```
 
-On bubba, `SCRIBE_BASE_URL=http://scribe:8000` is supplied by Compose. Restart
-only the podcast-rag pipeline, then verify one cache hit and one fresh episode
-through transcription, metadata extraction, Gemini File Search indexing, and
-audio cleanup.
+On bubba, Compose supplies `SCRIBE_BASE_URL=http://scribe:8000` on its trusted
+private network together with the explicit
+`SCRIBE_ALLOW_INSECURE_HTTP=true` opt-in. Restart only the podcast-rag pipeline,
+then verify one cache hit and one fresh episode through transcription, metadata
+extraction, Gemini File Search indexing, and audio cleanup.
 
 ## Rollback
 

--- a/docs/scribe-migration.md
+++ b/docs/scribe-migration.md
@@ -1,0 +1,102 @@
+# Scribe Transcription Migration
+
+This runbook covers the reversible compatibility phase. Scribe receives a copy
+of every completed transcript, while podcast-rag continues retaining transcript
+text for downstream metadata and indexing.
+
+## 1. Inventory
+
+Run database commands through Doppler:
+
+```bash
+doppler run -- python scripts/export_transcripts_to_scribe.py \
+  /tmp/podcast-rag-transcripts.jsonl --dry-run
+```
+
+Resolve every `skipped_missing_text` and `conflicting_file_hashes` row before
+cutover, or record it as an explicit exception. Invalid file hashes do not block
+export; those records are seeded with URL-only deduplication.
+
+## 2. Back up both stores
+
+- Run `scripts/backup-db.sh` for podcast-rag PostgreSQL.
+- Keep Scribe's API online for Pepper. Create a consistent live snapshot with
+  SQLite's backup API; do not copy only `scribe.db` while WAL writes are active:
+
+  ```bash
+  docker exec scribe python -c 'import sqlite3; source=sqlite3.connect("/data/scribe.db"); backup=sqlite3.connect("/data/scribe-preseed.db"); source.backup(backup); backup.close(); source.close()'
+  docker cp scribe:/data/scribe-preseed.db /secure/backup/path/scribe-preseed.db
+  ```
+
+  Store the copied snapshot outside the `scribe-data` volume so losing or
+  restoring that volume does not also lose the backup.
+- Record the backup paths and export manifest with the change record.
+
+## 3. Export
+
+```bash
+doppler run -- python scripts/export_transcripts_to_scribe.py \
+  /tmp/podcast-rag-transcripts.jsonl
+```
+
+The exporter writes owner-only JSONL plus
+`podcast-rag-transcripts.jsonl.manifest.json`. Preserve both until the migration
+and soak period are complete.
+
+## 4. Online canary
+
+Pepper is a live Scribe consumer. Keep the Scribe API and Cloudflare tunnel
+available throughout the migration. Copy the export into the running container,
+then seed and verify the first 100 records:
+
+```bash
+docker cp /tmp/podcast-rag-transcripts.jsonl \
+  scribe:/tmp/podcast-rag-transcripts.jsonl
+docker exec scribe scribe-seed /tmp/podcast-rag-transcripts.jsonl \
+  --owner podcast-rag --limit 100
+docker exec scribe scribe-seed /tmp/podcast-rag-transcripts.jsonl \
+  --owner podcast-rag --limit 100 --verify-only
+```
+
+The verification must report zero `missing`, `mismatched`, and `errored`
+records. Wait through at least one Pepper podcast-collector interval and inspect
+both services for elevated latency, HTTP failures, or `database is locked`.
+Pepper's collector fails open on transport errors, but a clean canary is still
+the gate for the full import.
+
+## 5. Full online seed and verify
+
+Run the idempotent full import while continuing to monitor Pepper and Scribe:
+
+```bash
+docker exec scribe scribe-seed /tmp/podcast-rag-transcripts.jsonl \
+  --owner podcast-rag
+docker exec scribe scribe-seed /tmp/podcast-rag-transcripts.jsonl \
+  --owner podcast-rag --verify-only
+```
+
+The full import skips the 100 canary rows. Verification must report zero
+`missing`, `mismatched`, and `errored` records, and re-running the seed must
+report zero imports. Abort before cutover if Pepper or Scribe shows sustained
+errors; the import does not require an application outage.
+
+## 6. Compatibility cutover
+
+Configure the podcast-rag Doppler production environment:
+
+```text
+TRANSCRIPTION_BACKEND=scribe
+SCRIBE_API_TOKEN=<podcast-rag consumer token>
+```
+
+On bubba, `SCRIBE_BASE_URL=http://scribe:8000` is supplied by Compose. Restart
+only the podcast-rag pipeline, then verify one cache hit and one fresh episode
+through transcription, metadata extraction, Gemini File Search indexing, and
+audio cleanup.
+
+## Rollback
+
+Set `TRANSCRIPTION_BACKEND=local` and restart the podcast-rag pipeline. During
+this phase all completed transcript text remains in PostgreSQL, so rollback does
+not require restoring data. Do not remove transcript text, Whisper dependencies,
+or podcast-rag's GPU reservation until the later remote-only phase is complete.

--- a/scripts/export_transcripts_to_scribe.py
+++ b/scripts/export_transcripts_to_scribe.py
@@ -172,7 +172,7 @@ def main(argv: list[str] | None = None) -> int:
             pool_pre_ping=config.DB_POOL_PRE_PING,
             echo=config.DB_ECHO,
         )
-    except Exception:
+    except (ValueError, SQLAlchemyError):
         logger.exception("Failed to initialize transcript export to %s", args.output.resolve())
         raise
     try:

--- a/scripts/export_transcripts_to_scribe.py
+++ b/scripts/export_transcripts_to_scribe.py
@@ -14,19 +14,25 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import logging
 import os
 import re
 import tempfile
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
+
+from sqlalchemy.exc import SQLAlchemyError
 
 from src.config import Config
 from src.db.factory import create_repository
 
 _SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+logger = logging.getLogger(__name__)
 
 
 def _record_for_episode(episode, transcript_text: str) -> tuple[dict[str, Any], bool]:
+    """Build one Scribe seed record and report whether its file hash is invalid."""
     file_hash = episode.file_hash
     valid_hash = bool(file_hash and _SHA256_RE.fullmatch(file_hash))
     record = {
@@ -45,9 +51,8 @@ def _record_for_episode(episode, transcript_text: str) -> tuple[dict[str, Any], 
 
 def export_transcripts(repository, output_path: Path, *, dry_run: bool = False) -> dict[str, Any]:
     """Export completed transcripts and return a verification manifest."""
-    episodes = repository.list_episodes(transcript_status="completed")
     manifest: dict[str, Any] = {
-        "completed_rows": len(episodes),
+        "completed_rows": 0,
         "exported_rows": 0,
         "skipped_missing_text": 0,
         "invalid_file_hashes": 0,
@@ -63,21 +68,28 @@ def export_transcripts(repository, output_path: Path, *, dry_run: bool = False) 
     digest = hashlib.sha256()
 
     output_path = output_path.resolve()
-    output_path.parent.mkdir(parents=True, exist_ok=True)
     temp_path: Path | None = None
+    manifest_temp: Path | None = None
     output = None
-    if not dry_run:
-        handle = tempfile.NamedTemporaryFile(
-            mode="wb", dir=output_path.parent, prefix=f".{output_path.name}.", delete=False
-        )
-        os.chmod(handle.name, 0o600)
-        temp_path = Path(handle.name)
-        output = handle
 
     try:
+        episodes = repository.list_episodes(transcript_status="completed")
+        manifest["completed_rows"] = len(episodes)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        if not dry_run:
+            handle = tempfile.NamedTemporaryFile(
+                mode="wb",
+                dir=output_path.parent,
+                prefix=f".{output_path.name}.",
+                delete=False,
+            )
+            os.chmod(handle.name, 0o600)
+            temp_path = Path(handle.name)
+            output = handle
+
         for episode in episodes:
             transcript_text = repository.get_transcript_text(episode.id)
-            if not transcript_text:
+            if transcript_text is None:
                 manifest["skipped_missing_text"] += 1
                 continue
 
@@ -107,30 +119,41 @@ def export_transcripts(repository, output_path: Path, *, dry_run: bool = False) 
             manifest["exported_rows"] += 1
             manifest["transcript_characters"] += len(transcript_text)
             manifest["jsonl_bytes"] += len(encoded)
-    except Exception:
-        if output is not None:
+
+        manifest["jsonl_sha256"] = digest.hexdigest()
+        if output is not None and temp_path is not None:
+            output.flush()
+            os.fsync(output.fileno())
             output.close()
-        if temp_path is not None:
-            temp_path.unlink(missing_ok=True)
+            output = None
+            os.replace(temp_path, output_path)
+            temp_path = None
+
+            manifest_path = output_path.with_suffix(output_path.suffix + ".manifest.json")
+            manifest_temp = manifest_path.with_suffix(manifest_path.suffix + ".tmp")
+            manifest_temp.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+            os.chmod(manifest_temp, 0o600)
+            os.replace(manifest_temp, manifest_path)
+            manifest_temp = None
+
+        return manifest
+    except (OSError, SQLAlchemyError):
+        logger.error("Failed to export transcripts to %s", output_path, exc_info=True)
         raise
-
-    manifest["jsonl_sha256"] = digest.hexdigest()
-    if output is not None and temp_path is not None:
-        output.flush()
-        os.fsync(output.fileno())
-        output.close()
-        os.replace(temp_path, output_path)
-
-        manifest_path = output_path.with_suffix(output_path.suffix + ".manifest.json")
-        manifest_temp = manifest_path.with_suffix(manifest_path.suffix + ".tmp")
-        manifest_temp.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
-        os.chmod(manifest_temp, 0o600)
-        os.replace(manifest_temp, manifest_path)
-
-    return manifest
+    finally:
+        if output is not None:
+            with suppress(OSError):
+                output.close()
+        if temp_path is not None:
+            with suppress(OSError):
+                temp_path.unlink(missing_ok=True)
+        if manifest_temp is not None:
+            with suppress(OSError):
+                manifest_temp.unlink(missing_ok=True)
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run the transcript export command and return a process exit status."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("output", type=Path, help="Destination JSONL file")
     parser.add_argument(

--- a/scripts/export_transcripts_to_scribe.py
+++ b/scripts/export_transcripts_to_scribe.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Export completed podcast-rag transcripts for Scribe's seed command.
+
+Run database-backed invocations through Doppler, for example:
+
+    doppler run -- python scripts/export_transcripts_to_scribe.py export.jsonl
+
+The JSONL and its manifest are written atomically with owner-only permissions.
+No database rows are modified.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from src.config import Config
+from src.db.factory import create_repository
+
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def _record_for_episode(episode, transcript_text: str) -> tuple[dict[str, Any], bool]:
+    file_hash = episode.file_hash
+    valid_hash = bool(file_hash and _SHA256_RE.fullmatch(file_hash))
+    record = {
+        "episode_id": episode.id,
+        "enclosure_url": episode.enclosure_url,
+        "transcript_text": transcript_text,
+        "transcript_sha256": hashlib.sha256(transcript_text.encode("utf-8")).hexdigest(),
+        "file_hash": file_hash.lower() if valid_hash else None,
+        "duration_seconds": episode.duration_seconds,
+        "transcript_status": "completed",
+        "model": episode.transcript_model,
+        "lang": episode.transcript_language or "en",
+    }
+    return record, bool(file_hash and not valid_hash)
+
+
+def export_transcripts(repository, output_path: Path, *, dry_run: bool = False) -> dict[str, Any]:
+    """Export completed transcripts and return a verification manifest."""
+    episodes = repository.list_episodes(transcript_status="completed")
+    manifest: dict[str, Any] = {
+        "completed_rows": len(episodes),
+        "exported_rows": 0,
+        "skipped_missing_text": 0,
+        "invalid_file_hashes": 0,
+        "duplicate_urls": 0,
+        "duplicate_file_hashes": 0,
+        "conflicting_file_hashes": 0,
+        "transcript_characters": 0,
+        "jsonl_bytes": 0,
+        "jsonl_sha256": None,
+    }
+    seen_urls: set[str] = set()
+    seen_hashes: dict[str, str] = {}
+    digest = hashlib.sha256()
+
+    output_path = output_path.resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: Path | None = None
+    output = None
+    if not dry_run:
+        handle = tempfile.NamedTemporaryFile(
+            mode="wb", dir=output_path.parent, prefix=f".{output_path.name}.", delete=False
+        )
+        os.chmod(handle.name, 0o600)
+        temp_path = Path(handle.name)
+        output = handle
+
+    try:
+        for episode in episodes:
+            transcript_text = repository.get_transcript_text(episode.id)
+            if not transcript_text:
+                manifest["skipped_missing_text"] += 1
+                continue
+
+            record, invalid_hash = _record_for_episode(episode, transcript_text)
+            manifest["invalid_file_hashes"] += int(invalid_hash)
+
+            url = record["enclosure_url"]
+            if url in seen_urls:
+                manifest["duplicate_urls"] += 1
+            seen_urls.add(url)
+
+            file_hash = record["file_hash"]
+            if file_hash:
+                if file_hash in seen_hashes:
+                    manifest["duplicate_file_hashes"] += 1
+                    if seen_hashes[file_hash] != record["transcript_sha256"]:
+                        manifest["conflicting_file_hashes"] += 1
+                else:
+                    seen_hashes[file_hash] = record["transcript_sha256"]
+
+            encoded = (json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n").encode(
+                "utf-8"
+            )
+            digest.update(encoded)
+            if output is not None:
+                output.write(encoded)
+            manifest["exported_rows"] += 1
+            manifest["transcript_characters"] += len(transcript_text)
+            manifest["jsonl_bytes"] += len(encoded)
+    except Exception:
+        if output is not None:
+            output.close()
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+        raise
+
+    manifest["jsonl_sha256"] = digest.hexdigest()
+    if output is not None and temp_path is not None:
+        output.flush()
+        os.fsync(output.fileno())
+        output.close()
+        os.replace(temp_path, output_path)
+
+        manifest_path = output_path.with_suffix(output_path.suffix + ".manifest.json")
+        manifest_temp = manifest_path.with_suffix(manifest_path.suffix + ".tmp")
+        manifest_temp.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+        os.chmod(manifest_temp, 0o600)
+        os.replace(manifest_temp, manifest_path)
+
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=Path, help="Destination JSONL file")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Inventory exportable rows without writing transcript data",
+    )
+    args = parser.parse_args(argv)
+
+    config = Config()
+    repository = create_repository(
+        database_url=config.DATABASE_URL,
+        pool_size=config.DB_POOL_SIZE,
+        max_overflow=config.DB_MAX_OVERFLOW,
+        pool_pre_ping=config.DB_POOL_PRE_PING,
+        echo=config.DB_ECHO,
+    )
+    try:
+        manifest = export_transcripts(repository, args.output, dry_run=args.dry_run)
+    finally:
+        repository.close()
+
+    print(json.dumps(manifest, indent=2))
+    clean = manifest["skipped_missing_text"] == 0 and manifest["conflicting_file_hashes"] == 0
+    return 0 if clean else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_transcripts_to_scribe.py
+++ b/scripts/export_transcripts_to_scribe.py
@@ -163,14 +163,18 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    config = Config()
-    repository = create_repository(
-        database_url=config.DATABASE_URL,
-        pool_size=config.DB_POOL_SIZE,
-        max_overflow=config.DB_MAX_OVERFLOW,
-        pool_pre_ping=config.DB_POOL_PRE_PING,
-        echo=config.DB_ECHO,
-    )
+    try:
+        config = Config()
+        repository = create_repository(
+            database_url=config.DATABASE_URL,
+            pool_size=config.DB_POOL_SIZE,
+            max_overflow=config.DB_MAX_OVERFLOW,
+            pool_pre_ping=config.DB_POOL_PRE_PING,
+            echo=config.DB_ECHO,
+        )
+    except Exception:
+        logger.exception("Failed to initialize transcript export to %s", args.output.resolve())
+        raise
     try:
         manifest = export_transcripts(repository, args.output, dry_run=args.dry_run)
     finally:

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 
 from dotenv import load_dotenv
@@ -58,6 +59,34 @@ class Config:
         self.WHISPER_DEVICE = os.getenv("WHISPER_DEVICE", "cuda")
         # Compute type: float16 (GPU), int8 (CPU), float32
         self.WHISPER_COMPUTE_TYPE = os.getenv("WHISPER_COMPUTE_TYPE", "float16")
+
+        # Transcription backend. "local" preserves the existing faster-whisper
+        # path; "scribe" delegates to the shared transcription service.
+        self.TRANSCRIPTION_BACKEND = os.getenv(
+            "TRANSCRIPTION_BACKEND", "local"
+        ).lower()
+        if self.TRANSCRIPTION_BACKEND not in {"local", "scribe"}:
+            raise ValueError(
+                "TRANSCRIPTION_BACKEND must be 'local' or 'scribe', got: "
+                f"{self.TRANSCRIPTION_BACKEND}"
+            )
+        self.SCRIBE_BASE_URL = os.getenv(
+            "SCRIBE_BASE_URL", "http://scribe:8000"
+        ).rstrip("/")
+        if not self.SCRIBE_BASE_URL.lower().startswith(("http://", "https://")):
+            raise ValueError(
+                f"SCRIBE_BASE_URL must start with http:// or https://, got: {self.SCRIBE_BASE_URL}"
+            )
+        self.SCRIBE_API_TOKEN = os.getenv("SCRIBE_API_TOKEN", "")
+        self.SCRIBE_REQUEST_TIMEOUT = float(
+            os.getenv("SCRIBE_REQUEST_TIMEOUT", "30")
+        )
+        if not math.isfinite(self.SCRIBE_REQUEST_TIMEOUT) or self.SCRIBE_REQUEST_TIMEOUT <= 0:
+            raise ValueError(
+                "SCRIBE_REQUEST_TIMEOUT must be positive, got: "
+                f"{self.SCRIBE_REQUEST_TIMEOUT}"
+            )
+        self.SCRIBE_LANGUAGE = os.getenv("SCRIBE_LANGUAGE", "en") or None
 
         # Model configuration
         self.GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "your_api_key_here")

--- a/src/config.py
+++ b/src/config.py
@@ -1,8 +1,44 @@
 import json
-import math
 import os
+from typing import Literal, Self
 
 from dotenv import load_dotenv
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class ScribeSettings(BaseModel):
+    """Validated environment-backed settings for the Scribe integration."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, validate_default=True)
+
+    transcription_backend: Literal["local", "scribe"] = "local"
+    base_url: AnyHttpUrl = "https://scribe.vycari.ai"
+    api_token: str = ""
+    request_timeout: float = Field(default=30.0, gt=0, allow_inf_nan=False)
+    language: str | None = "en"
+    allow_insecure_http: bool = False
+
+    @field_validator("transcription_backend", mode="before")
+    @classmethod
+    def normalize_backend(cls, value: object) -> object:
+        """Normalize backend names before validating the allowed values."""
+        return value.lower() if isinstance(value, str) else value
+
+    @field_validator("language", mode="before")
+    @classmethod
+    def normalize_language(cls, value: object) -> object:
+        """Treat an empty language hint as Scribe auto-detection."""
+        return value or None
+
+    @model_validator(mode="after")
+    def require_secure_transport(self) -> Self:
+        """Reject cleartext Scribe traffic without an explicit local-development opt-in."""
+        if self.base_url.scheme == "http" and not self.allow_insecure_http:
+            raise ValueError(
+                "SCRIBE_BASE_URL must use https://; set "
+                "SCRIBE_ALLOW_INSECURE_HTTP=true only for trusted local development"
+            )
+        return self
 
 
 def _load_doppler_env():
@@ -62,31 +98,22 @@ class Config:
 
         # Transcription backend. "local" preserves the existing faster-whisper
         # path; "scribe" delegates to the shared transcription service.
-        self.TRANSCRIPTION_BACKEND = os.getenv(
-            "TRANSCRIPTION_BACKEND", "local"
-        ).lower()
-        if self.TRANSCRIPTION_BACKEND not in {"local", "scribe"}:
-            raise ValueError(
-                "TRANSCRIPTION_BACKEND must be 'local' or 'scribe', got: "
-                f"{self.TRANSCRIPTION_BACKEND}"
-            )
-        self.SCRIBE_BASE_URL = os.getenv(
-            "SCRIBE_BASE_URL", "http://scribe:8000"
-        ).rstrip("/")
-        if not self.SCRIBE_BASE_URL.lower().startswith(("http://", "https://")):
-            raise ValueError(
-                f"SCRIBE_BASE_URL must start with http:// or https://, got: {self.SCRIBE_BASE_URL}"
-            )
-        self.SCRIBE_API_TOKEN = os.getenv("SCRIBE_API_TOKEN", "")
-        self.SCRIBE_REQUEST_TIMEOUT = float(
-            os.getenv("SCRIBE_REQUEST_TIMEOUT", "30")
+        scribe = ScribeSettings.model_validate(
+            {
+                "transcription_backend": os.getenv("TRANSCRIPTION_BACKEND", "local"),
+                "base_url": os.getenv("SCRIBE_BASE_URL", "https://scribe.vycari.ai"),
+                "api_token": os.getenv("SCRIBE_API_TOKEN", ""),
+                "request_timeout": os.getenv("SCRIBE_REQUEST_TIMEOUT", "30"),
+                "language": os.getenv("SCRIBE_LANGUAGE", "en"),
+                "allow_insecure_http": os.getenv("SCRIBE_ALLOW_INSECURE_HTTP", "false"),
+            }
         )
-        if not math.isfinite(self.SCRIBE_REQUEST_TIMEOUT) or self.SCRIBE_REQUEST_TIMEOUT <= 0:
-            raise ValueError(
-                "SCRIBE_REQUEST_TIMEOUT must be positive, got: "
-                f"{self.SCRIBE_REQUEST_TIMEOUT}"
-            )
-        self.SCRIBE_LANGUAGE = os.getenv("SCRIBE_LANGUAGE", "en") or None
+        self.TRANSCRIPTION_BACKEND = scribe.transcription_backend
+        self.SCRIBE_BASE_URL = str(scribe.base_url).rstrip("/")
+        self.SCRIBE_API_TOKEN = scribe.api_token
+        self.SCRIBE_REQUEST_TIMEOUT = float(scribe.request_timeout)
+        self.SCRIBE_LANGUAGE = scribe.language
+        self.SCRIBE_ALLOW_INSECURE_HTTP = scribe.allow_insecure_http
 
         # Model configuration
         self.GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "your_api_key_here")

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -173,6 +173,10 @@ class Episode(Base):
     transcript_error: Mapped[str | None] = mapped_column(Text)
     transcript_path: Mapped[str | None] = mapped_column(String(1024))
     transcript_text: Mapped[str | None] = mapped_column(Text)  # Full transcript content
+    transcript_provider: Mapped[str | None] = mapped_column(String(32))
+    transcript_external_id: Mapped[str | None] = mapped_column(String(64))
+    transcript_model: Mapped[str | None] = mapped_column(String(64))
+    transcript_language: Mapped[str | None] = mapped_column(String(16))
     transcribed_at: Mapped[datetime | None] = mapped_column(DateTime)
 
     # MP3 ID3 tag metadata

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -601,6 +601,10 @@ class PodcastRepositoryInterface(ABC):
         episode_id: str,
         transcript_text: str,
         transcript_path: str | None = None,
+        provider: str | None = None,
+        external_id: str | None = None,
+        model: str | None = None,
+        language: str | None = None,
     ) -> None:
         """
         Mark an episode's transcription as completed and store the transcript content.
@@ -616,7 +620,25 @@ class PodcastRepositoryInterface(ABC):
         pass
 
     @abstractmethod
-    def mark_transcript_failed(self, episode_id: str, error: str) -> None:
+    def mark_transcript_remote_status(
+        self,
+        episode_id: str,
+        *,
+        provider: str,
+        external_id: str,
+        status: str = "processing",
+    ) -> None:
+        """Record a remote transcript handle and its non-terminal status."""
+        pass
+
+    @abstractmethod
+    def mark_transcript_failed(
+        self,
+        episode_id: str,
+        error: str,
+        provider: str | None = None,
+        external_id: str | None = None,
+    ) -> None:
         """
         Mark an episode's transcription as failed and record the failure reason.
 
@@ -2185,7 +2207,13 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
                 select(Episode)
                 .where(
                     Episode.download_status == "completed",
-                    Episode.transcript_status == "pending",
+                    or_(
+                        Episode.transcript_status == "pending",
+                        and_(
+                            Episode.transcript_status == "processing",
+                            Episode.transcript_provider == "scribe",
+                        ),
+                    ),
                     Episode.local_file_path.isnot(None),
                 )
                 .order_by(Episode.published_date.desc())
@@ -2409,6 +2437,10 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
         episode_id: str,
         transcript_text: str,
         transcript_path: str | None = None,
+        provider: str | None = None,
+        external_id: str | None = None,
+        model: str | None = None,
+        language: str | None = None,
     ) -> None:
         """
         Mark an episode's transcription as complete and store the transcript content.
@@ -2428,11 +2460,40 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
             transcript_status="completed",
             transcript_text=transcript_text,
             transcript_path=transcript_path,
+            transcript_provider=provider,
+            transcript_external_id=external_id,
+            transcript_model=model,
+            transcript_language=language,
             transcribed_at=datetime.now(UTC),
             transcript_error=None,
         )
 
-    def mark_transcript_failed(self, episode_id: str, error: str) -> None:
+    def mark_transcript_remote_status(
+        self,
+        episode_id: str,
+        *,
+        provider: str,
+        external_id: str,
+        status: str = "processing",
+    ) -> None:
+        """Record an in-flight remote transcription without treating it as failure."""
+        if status not in {"queued", "processing"}:
+            raise ValueError(f"Invalid remote transcript status: {status}")
+        self.update_episode(
+            episode_id,
+            transcript_status="processing",
+            transcript_provider=provider,
+            transcript_external_id=external_id,
+            transcript_error=None,
+        )
+
+    def mark_transcript_failed(
+        self,
+        episode_id: str,
+        error: str,
+        provider: str | None = None,
+        external_id: str | None = None,
+    ) -> None:
         """
         Mark an episode's transcription as failed and record the error message.
 
@@ -2444,6 +2505,8 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
             episode_id,
             transcript_status="failed",
             transcript_error=error,
+            transcript_provider=provider,
+            transcript_external_id=external_id,
         )
 
     def mark_metadata_started(self, episode_id: str) -> None:
@@ -3030,7 +3093,13 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
                 select(Episode)
                 .where(
                     Episode.download_status == "completed",
-                    Episode.transcript_status == "pending",
+                    or_(
+                        Episode.transcript_status == "pending",
+                        and_(
+                            Episode.transcript_status == "processing",
+                            Episode.transcript_provider == "scribe",
+                        ),
+                    ),
                     Episode.local_file_path.isnot(None),
                 )
                 .order_by(Episode.published_date.desc())

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -443,12 +443,15 @@ class PodcastRepositoryInterface(ABC):
         pass
 
     @abstractmethod
-    def get_episodes_pending_transcription(self, limit: int = 10) -> list[Episode]:
+    def get_episodes_pending_transcription(
+        self, limit: int = 10, backend: str = "local"
+    ) -> list[Episode]:
         """
         Retrieve downloaded episodes that still require transcription.
 
         Parameters:
             limit (int): Maximum number of episodes to return.
+            backend: Active transcription backend (``local`` or ``scribe``).
 
         Returns:
             List[Episode]: Episodes where the download is completed, transcription has not started or is pending, and a local audio file is present, ordered by most recently published.
@@ -961,11 +964,14 @@ class PodcastRepositoryInterface(ABC):
         pass
 
     @abstractmethod
-    def get_next_for_transcription(self) -> Episode | None:
+    def get_next_for_transcription(self, backend: str = "local") -> Episode | None:
         """Get the next episode ready for transcription.
 
         Returns the most recently published episode that is downloaded
         and pending transcription, excluding permanently failed episodes.
+
+        Args:
+            backend: Active transcription backend (``local`` or ``scribe``).
 
         Returns:
             Episode ready for transcription, or None if none available.
@@ -2196,24 +2202,32 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
             )
             return list(session.scalars(stmt).all())
 
-    def get_episodes_pending_transcription(self, limit: int = 10) -> list[Episode]:
+    def get_episodes_pending_transcription(
+        self, limit: int = 10, backend: str = "local"
+    ) -> list[Episode]:
         """
         Return episodes that have been downloaded and are awaiting transcription.
 
         @returns List[Episode]: Episodes with download_status == "completed", transcript_status == "pending", and a non-null local_file_path, ordered by published_date descending and limited to the provided `limit`.
         """
+        if backend not in {"local", "scribe"}:
+            raise ValueError(f"Invalid transcription backend: {backend}")
+        transcript_condition = Episode.transcript_status == "pending"
+        if backend == "scribe":
+            transcript_condition = or_(
+                transcript_condition,
+                and_(
+                    Episode.transcript_status == "processing",
+                    Episode.transcript_provider == "scribe",
+                ),
+            )
+
         with self._get_session() as session:
             stmt = (
                 select(Episode)
                 .where(
                     Episode.download_status == "completed",
-                    or_(
-                        Episode.transcript_status == "pending",
-                        and_(
-                            Episode.transcript_status == "processing",
-                            Episode.transcript_provider == "scribe",
-                        ),
-                    ),
+                    transcript_condition,
                     Episode.local_file_path.isnot(None),
                 )
                 .order_by(Episode.published_date.desc())
@@ -3079,7 +3093,7 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
             )
             return session.scalar(stmt) or 0
 
-    def get_next_for_transcription(self) -> Episode | None:
+    def get_next_for_transcription(self, backend: str = "local") -> Episode | None:
         """Get the next single episode ready for transcription.
 
         Returns episodes ordered by published_date (newest first),
@@ -3088,18 +3102,24 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
         Returns:
             Episode to transcribe, or None if no work available.
         """
+        if backend not in {"local", "scribe"}:
+            raise ValueError(f"Invalid transcription backend: {backend}")
+        transcript_condition = Episode.transcript_status == "pending"
+        if backend == "scribe":
+            transcript_condition = or_(
+                transcript_condition,
+                and_(
+                    Episode.transcript_status == "processing",
+                    Episode.transcript_provider == "scribe",
+                ),
+            )
+
         with self._get_session() as session:
             stmt = (
                 select(Episode)
                 .where(
                     Episode.download_status == "completed",
-                    or_(
-                        Episode.transcript_status == "pending",
-                        and_(
-                            Episode.transcript_status == "processing",
-                            Episode.transcript_provider == "scribe",
-                        ),
-                    ),
+                    transcript_condition,
                     Episode.local_file_path.isnot(None),
                 )
                 .order_by(Episode.published_date.desc())

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -652,6 +652,17 @@ class PodcastRepositoryInterface(ABC):
         pass
 
     @abstractmethod
+    def record_transcript_error(
+        self,
+        episode_id: str,
+        error: str,
+        provider: str | None = None,
+        external_id: str | None = None,
+    ) -> None:
+        """Record a retryable transcript error without changing its status."""
+        pass
+
+    @abstractmethod
     def mark_metadata_started(self, episode_id: str) -> None:
         """Mark episode metadata extraction as started."""
         pass
@@ -2212,10 +2223,16 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
         """
         if backend not in {"local", "scribe"}:
             raise ValueError(f"Invalid transcription backend: {backend}")
-        transcript_condition = Episode.transcript_status == "pending"
+        transcript_condition = and_(
+            Episode.transcript_status == "pending",
+            or_(
+                Episode.transcript_provider.is_(None),
+                Episode.transcript_provider != "scribe",
+            ),
+        )
         if backend == "scribe":
             transcript_condition = or_(
-                transcript_condition,
+                Episode.transcript_status == "pending",
                 and_(
                     Episode.transcript_status == "processing",
                     Episode.transcript_provider == "scribe",
@@ -2522,6 +2539,22 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
             transcript_provider=provider,
             transcript_external_id=external_id,
         )
+
+    def record_transcript_error(
+        self,
+        episode_id: str,
+        error: str,
+        provider: str | None = None,
+        external_id: str | None = None,
+    ) -> None:
+        """Record a retryable transcript error while preserving its pollable status."""
+        fields = {
+            "transcript_error": error,
+            "transcript_provider": provider,
+        }
+        if external_id is not None:
+            fields["transcript_external_id"] = external_id
+        self.update_episode(episode_id, **fields)
 
     def mark_metadata_started(self, episode_id: str) -> None:
         """
@@ -3104,10 +3137,16 @@ class SQLAlchemyPodcastRepository(PodcastRepositoryInterface):
         """
         if backend not in {"local", "scribe"}:
             raise ValueError(f"Invalid transcription backend: {backend}")
-        transcript_condition = Episode.transcript_status == "pending"
+        transcript_condition = and_(
+            Episode.transcript_status == "pending",
+            or_(
+                Episode.transcript_provider.is_(None),
+                Episode.transcript_provider != "scribe",
+            ),
+        )
         if backend == "scribe":
             transcript_condition = or_(
-                transcript_condition,
+                Episode.transcript_status == "pending",
                 and_(
                     Episode.transcript_status == "processing",
                     Episode.transcript_provider == "scribe",

--- a/src/services/scribe.py
+++ b/src/services/scribe.py
@@ -2,60 +2,66 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
+import logging
+import time
+from collections.abc import Callable
+from typing import Any, Literal
 
 import requests
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, ValidationError, model_validator
 
-_VALID_STATUSES = {"queued", "processing", "completed", "failed"}
+logger = logging.getLogger(__name__)
+
+_RETRYABLE_STATUS_CODES = {408, 425, 429, 500, 502, 503, 504}
+
+
+class _ScribeRequest(BaseModel):
+    """Validated request body accepted by Scribe's v1 endpoint."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    audio_url: AnyHttpUrl
+    language: str | None = None
+    hint_guid: str | None = None
+    hint_title: str | None = None
 
 
 class ScribeClientError(RuntimeError):
     """A Scribe request failed or returned an invalid response."""
 
+    def __init__(self, message: str, *, retryable: bool = False):
+        super().__init__(message)
+        self.retryable = retryable
 
-@dataclass(frozen=True)
-class ScribeTranscript:
+
+class ScribeTranscript(BaseModel):
     """Validated response from Scribe."""
 
-    id: str
-    status: str
+    model_config = ConfigDict(extra="ignore", frozen=True, populate_by_name=True, strict=True)
+
+    id: str = Field(min_length=1)
+    status: Literal["queued", "processing", "completed", "failed"]
     transcript_id: str | None = None
     transcript: str | None = None
-    language: str | None = None
+    language: str | None = Field(default=None, alias="lang")
     error: str | None = None
-    duration_seconds: float | None = None
+    duration_seconds: float | None = Field(default=None, ge=0, allow_inf_nan=False)
     model: str | None = None
+
+    @model_validator(mode="after")
+    def require_completed_transcript(self) -> ScribeTranscript:
+        """Require transcript text, including an allowed empty string, on completion."""
+        if self.status == "completed" and self.transcript is None:
+            raise ValueError("completed Scribe response is missing transcript text")
+        return self
 
     @classmethod
     def from_payload(cls, payload: Any) -> ScribeTranscript:
-        if not isinstance(payload, dict):
-            raise ScribeClientError("Scribe returned a non-object response")
-
-        handle = payload.get("id")
-        status = payload.get("status")
-        if not isinstance(handle, str) or not handle:
-            raise ScribeClientError("Scribe response is missing an id")
-        if status not in _VALID_STATUSES:
-            raise ScribeClientError(f"Scribe returned an invalid status: {status!r}")
-
-        transcript_id = payload.get("transcript_id")
-        if transcript_id is not None and not isinstance(transcript_id, str):
-            raise ScribeClientError("Scribe returned an invalid transcript_id")
-        transcript = payload.get("transcript")
-        if status == "completed" and not isinstance(transcript, str):
-            raise ScribeClientError("Completed Scribe response is missing transcript text")
-
-        return cls(
-            id=handle,
-            transcript_id=transcript_id,
-            status=status,
-            transcript=transcript,
-            language=payload.get("lang"),
-            error=payload.get("error"),
-            duration_seconds=payload.get("duration_seconds"),
-            model=payload.get("model"),
-        )
+        """Parse a Scribe response and normalize validation failures."""
+        try:
+            return cls.model_validate(payload)
+        except ValidationError as exc:
+            raise ScribeClientError(f"Invalid Scribe response: {exc}") from exc
 
 
 class ScribeClient:
@@ -68,11 +74,22 @@ class ScribeClient:
         api_token: str,
         timeout: float = 30.0,
         session: requests.Session | None = None,
+        max_attempts: int = 3,
+        backoff_seconds: float = 0.5,
+        sleep: Callable[[float], None] = time.sleep,
     ):
+        """Initialize an authenticated client with bounded retry behavior."""
         if not api_token:
             raise ValueError("SCRIBE_API_TOKEN is required when using Scribe")
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be at least 1")
+        if backoff_seconds < 0:
+            raise ValueError("backoff_seconds must be non-negative")
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
+        self._max_attempts = max_attempts
+        self._backoff_seconds = backoff_seconds
+        self._sleep = sleep
         self._session = session or requests.Session()
         self._session.headers.update(
             {
@@ -90,22 +107,51 @@ class ScribeClient:
         hint_title: str | None = None,
     ) -> ScribeTranscript:
         """Submit or poll an idempotent transcription request."""
-        body = {
-            "audio_url": audio_url,
-            "language": language,
-            "hint_guid": hint_guid,
-            "hint_title": hint_title,
-        }
         try:
-            response = self._session.post(
-                f"{self._base_url}/v1/transcripts",
-                json=body,
-                timeout=self._timeout,
-            )
-            response.raise_for_status()
+            body = _ScribeRequest(
+                audio_url=audio_url,
+                language=language,
+                hint_guid=hint_guid,
+                hint_title=hint_title,
+            ).model_dump(mode="json")
+        except ValidationError as exc:
+            raise ScribeClientError(f"Invalid Scribe request: {exc}") from exc
+
+        response = None
+        for attempt in range(1, self._max_attempts + 1):
+            try:
+                response = self._session.post(
+                    f"{self._base_url}/v1/transcripts",
+                    json=body,
+                    timeout=self._timeout,
+                )
+                if response.status_code in _RETRYABLE_STATUS_CODES:
+                    raise requests.HTTPError(
+                        f"retryable Scribe HTTP status {response.status_code}",
+                        response=response,
+                    )
+                response.raise_for_status()
+                break
+            except requests.RequestException as exc:
+                status_code = getattr(getattr(exc, "response", None), "status_code", None)
+                retryable = not isinstance(exc, requests.HTTPError) or (
+                    status_code in _RETRYABLE_STATUS_CODES
+                )
+                if retryable and attempt < self._max_attempts:
+                    self._sleep(self._backoff_seconds * (2 ** (attempt - 1)))
+                    continue
+                logger.error(
+                    "Scribe request failed after %d attempt(s)",
+                    attempt,
+                    exc_info=True,
+                )
+                raise ScribeClientError(
+                    f"Scribe request failed: {exc}", retryable=retryable
+                ) from exc
+
+        assert response is not None
+        try:
             payload = response.json()
-        except requests.RequestException as exc:
-            raise ScribeClientError(f"Scribe request failed: {exc}") from exc
         except ValueError as exc:
             raise ScribeClientError("Scribe returned invalid JSON") from exc
 

--- a/src/services/scribe.py
+++ b/src/services/scribe.py
@@ -1,0 +1,112 @@
+"""Client for the shared Scribe transcription service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+_VALID_STATUSES = {"queued", "processing", "completed", "failed"}
+
+
+class ScribeClientError(RuntimeError):
+    """A Scribe request failed or returned an invalid response."""
+
+
+@dataclass(frozen=True)
+class ScribeTranscript:
+    """Validated response from Scribe."""
+
+    id: str
+    status: str
+    transcript_id: str | None = None
+    transcript: str | None = None
+    language: str | None = None
+    error: str | None = None
+    duration_seconds: float | None = None
+    model: str | None = None
+
+    @classmethod
+    def from_payload(cls, payload: Any) -> ScribeTranscript:
+        if not isinstance(payload, dict):
+            raise ScribeClientError("Scribe returned a non-object response")
+
+        handle = payload.get("id")
+        status = payload.get("status")
+        if not isinstance(handle, str) or not handle:
+            raise ScribeClientError("Scribe response is missing an id")
+        if status not in _VALID_STATUSES:
+            raise ScribeClientError(f"Scribe returned an invalid status: {status!r}")
+
+        transcript_id = payload.get("transcript_id")
+        if transcript_id is not None and not isinstance(transcript_id, str):
+            raise ScribeClientError("Scribe returned an invalid transcript_id")
+        transcript = payload.get("transcript")
+        if status == "completed" and not isinstance(transcript, str):
+            raise ScribeClientError("Completed Scribe response is missing transcript text")
+
+        return cls(
+            id=handle,
+            transcript_id=transcript_id,
+            status=status,
+            transcript=transcript,
+            language=payload.get("lang"),
+            error=payload.get("error"),
+            duration_seconds=payload.get("duration_seconds"),
+            model=payload.get("model"),
+        )
+
+
+class ScribeClient:
+    """Bearer-authenticated, idempotent Scribe API client."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_token: str,
+        timeout: float = 30.0,
+        session: requests.Session | None = None,
+    ):
+        if not api_token:
+            raise ValueError("SCRIBE_API_TOKEN is required when using Scribe")
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._session = session or requests.Session()
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {api_token}",
+                "Accept": "application/json",
+            }
+        )
+
+    def submit(
+        self,
+        *,
+        audio_url: str,
+        language: str | None = None,
+        hint_guid: str | None = None,
+        hint_title: str | None = None,
+    ) -> ScribeTranscript:
+        """Submit or poll an idempotent transcription request."""
+        body = {
+            "audio_url": audio_url,
+            "language": language,
+            "hint_guid": hint_guid,
+            "hint_title": hint_title,
+        }
+        try:
+            response = self._session.post(
+                f"{self._base_url}/v1/transcripts",
+                json=body,
+                timeout=self._timeout,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except requests.RequestException as exc:
+            raise ScribeClientError(f"Scribe request failed: {exc}") from exc
+        except ValueError as exc:
+            raise ScribeClientError("Scribe returned invalid JSON") from exc
+
+        return ScribeTranscript.from_payload(payload)

--- a/src/workflow/orchestrator.py
+++ b/src/workflow/orchestrator.py
@@ -338,7 +338,8 @@ class PipelineOrchestrator:
         self._maintain_download_buffer()
 
         # 3. Get next episode to transcribe
-        episode = self.repository.get_next_for_transcription()
+        backend = getattr(self.config, "TRANSCRIPTION_BACKEND", "local")
+        episode = self.repository.get_next_for_transcription(backend=backend)
 
         if episode is None:
             return False
@@ -361,6 +362,15 @@ class PipelineOrchestrator:
                 transcription_result.status,
             )
             return False
+        elif transcription_result.is_terminal:
+            self._stats.transcription_failures += 1
+            self._stats.transcription_permanent_failures += 1
+            logger.warning(
+                "Episode %s has a terminal %s transcription failure; preserving it",
+                episode.id,
+                transcription_result.provider or "remote",
+            )
+            return True
         else:
             # Check if failure was due to shutdown
             if not self._running:
@@ -396,6 +406,9 @@ class PipelineOrchestrator:
                         f"Episode {episode.id} transcription reset for retry "
                         f"{retry_count}/{self.pipeline_config.max_retries}"
                     )
+
+                if transcription_result.should_backoff:
+                    return False
 
         return True
 
@@ -607,7 +620,10 @@ class PipelineOrchestrator:
         # Get pending counts
         try:
             status["pending_transcription"] = len(
-                self.repository.get_episodes_pending_transcription(limit=1000)
+                self.repository.get_episodes_pending_transcription(
+                    limit=1000,
+                    backend=getattr(self.config, "TRANSCRIPTION_BACKEND", "local"),
+                )
             )
         except Exception:
             status["pending_transcription"] = -1

--- a/src/workflow/orchestrator.py
+++ b/src/workflow/orchestrator.py
@@ -132,11 +132,19 @@ class PipelineOrchestrator:
     def _get_transcription_worker(self):
         """Get or create the transcription worker."""
         if self._transcription_worker is None:
-            from src.workflow.workers.transcription import TranscriptionWorker
+            if getattr(self.config, "TRANSCRIPTION_BACKEND", "local") == "scribe":
+                from src.workflow.workers.scribe_transcription import (
+                    ScribeTranscriptionWorker,
+                )
 
-            self._transcription_worker = TranscriptionWorker(
-                config=self.config,
-                repository=self.repository,
+                worker_class = ScribeTranscriptionWorker
+            else:
+                from src.workflow.workers.transcription import TranscriptionWorker
+
+                worker_class = TranscriptionWorker
+
+            self._transcription_worker = worker_class(
+                config=self.config, repository=self.repository
             )
         return self._transcription_worker
 
@@ -338,14 +346,21 @@ class PipelineOrchestrator:
         # 4. Transcribe (blocking, GPU-bound)
         logger.info(f"Transcribing: {episode.title}")
         transcription_worker = self._get_transcription_worker()
-        transcript_path = transcription_worker.transcribe_single(episode)
+        transcription_result = transcription_worker.transcribe_single(episode)
 
-        if transcript_path:
+        if transcription_result.is_complete:
             self._stats.episodes_transcribed += 1
 
             # 5. Submit for async post-processing
             if self._post_processor:
                 self._post_processor.submit(episode.id)
+        elif transcription_result.is_waiting:
+            logger.info(
+                "Episode %s is %s in Scribe; will poll again",
+                episode.id,
+                transcription_result.status,
+            )
+            return False
         else:
             # Check if failure was due to shutdown
             if not self._running:

--- a/src/workflow/workers/__init__.py
+++ b/src/workflow/workers/__init__.py
@@ -9,9 +9,10 @@ Each worker handles a single stage of the pipeline:
 - CleanupWorker: Removes audio files for fully processed episodes
 """
 
-from src.workflow.workers.base import WorkerInterface, WorkerResult
+from src.workflow.workers.base import TranscriptionResult, WorkerInterface, WorkerResult
 
 __all__ = [
     "WorkerInterface",
     "WorkerResult",
+    "TranscriptionResult",
 ]

--- a/src/workflow/workers/base.py
+++ b/src/workflow/workers/base.py
@@ -41,6 +41,24 @@ class WorkerResult:
         )
 
 
+@dataclass(frozen=True)
+class TranscriptionResult:
+    """Outcome of one local or remote transcription attempt."""
+
+    status: str
+    transcript_text: str | None = None
+    external_id: str | None = None
+    error: str | None = None
+
+    @property
+    def is_complete(self) -> bool:
+        return self.status == "completed"
+
+    @property
+    def is_waiting(self) -> bool:
+        return self.status in {"queued", "processing"}
+
+
 class WorkerInterface(ABC):
     """Abstract base class for workflow workers.
 

--- a/src/workflow/workers/base.py
+++ b/src/workflow/workers/base.py
@@ -47,16 +47,30 @@ class TranscriptionResult:
 
     status: str
     transcript_text: str | None = None
+    provider: str | None = None
     external_id: str | None = None
     error: str | None = None
+    terminal: bool = False
 
     @property
     def is_complete(self) -> bool:
+        """Return whether transcription completed successfully."""
         return self.status == "completed"
 
     @property
     def is_waiting(self) -> bool:
+        """Return whether remote work is still in progress."""
         return self.status in {"queued", "processing"}
+
+    @property
+    def is_terminal(self) -> bool:
+        """Return whether a failed outcome must never be retried."""
+        return self.terminal
+
+    @property
+    def should_backoff(self) -> bool:
+        """Return whether orchestration should pause before another attempt."""
+        return self.status == "retryable"
 
 
 class WorkerInterface(ABC):

--- a/src/workflow/workers/scribe_transcription.py
+++ b/src/workflow/workers/scribe_transcription.py
@@ -118,11 +118,23 @@ class ScribeTranscriptionWorker(WorkerInterface):
                 exc_info=True,
             )
             external_id = getattr(episode, "transcript_external_id", None)
-            self.repository.mark_transcript_failed(
-                episode.id,
-                error,
-                provider="scribe",
-                external_id=external_id,
+            if not exc.retryable:
+                self.repository.mark_transcript_failed(
+                    episode.id,
+                    error,
+                    provider="scribe",
+                    external_id=external_id,
+                )
+                return TranscriptionResult(
+                    status="failed",
+                    provider="scribe",
+                    external_id=external_id,
+                    error=error,
+                    terminal=True,
+                )
+
+            self.repository.record_transcript_error(
+                episode.id, error, provider="scribe", external_id=external_id
             )
             return TranscriptionResult(
                 status="retryable",

--- a/src/workflow/workers/scribe_transcription.py
+++ b/src/workflow/workers/scribe_transcription.py
@@ -7,7 +7,7 @@ import logging
 from src.config import Config
 from src.db.models import Episode
 from src.db.repository import PodcastRepositoryInterface
-from src.services.scribe import ScribeClient
+from src.services.scribe import ScribeClient, ScribeClientError
 from src.workflow.workers.base import TranscriptionResult, WorkerInterface, WorkerResult
 
 logger = logging.getLogger(__name__)
@@ -46,7 +46,8 @@ class ScribeTranscriptionWorker(WorkerInterface):
         return True
 
     def get_pending_count(self) -> int:
-        return len(self.repository.get_episodes_pending_transcription(limit=1000))
+        """Count pending episodes and in-flight Scribe jobs."""
+        return len(self.repository.get_episodes_pending_transcription(limit=1000, backend="scribe"))
 
     def transcribe_single(self, episode: Episode) -> TranscriptionResult:
         """Submit or poll one episode, updating podcast-rag compatibility state."""
@@ -73,6 +74,7 @@ class ScribeTranscriptionWorker(WorkerInterface):
                 )
                 return TranscriptionResult(
                     status=response.status,
+                    provider="scribe",
                     external_id=response.id,
                 )
 
@@ -90,6 +92,7 @@ class ScribeTranscriptionWorker(WorkerInterface):
                 return TranscriptionResult(
                     status="completed",
                     transcript_text=response.transcript,
+                    provider="scribe",
                     external_id=external_id,
                 )
 
@@ -102,6 +105,28 @@ class ScribeTranscriptionWorker(WorkerInterface):
             )
             return TranscriptionResult(
                 status="failed",
+                provider="scribe",
+                external_id=external_id,
+                error=error,
+                terminal=True,
+            )
+        except ScribeClientError as exc:
+            error = str(exc)
+            logger.error(
+                "Scribe request failed for episode %s",
+                episode.id,
+                exc_info=True,
+            )
+            external_id = getattr(episode, "transcript_external_id", None)
+            self.repository.mark_transcript_failed(
+                episode.id,
+                error,
+                provider="scribe",
+                external_id=external_id,
+            )
+            return TranscriptionResult(
+                status="retryable",
+                provider="scribe",
                 external_id=external_id,
                 error=error,
             )
@@ -114,11 +139,13 @@ class ScribeTranscriptionWorker(WorkerInterface):
                 provider="scribe",
                 external_id=getattr(episode, "transcript_external_id", None),
             )
-            return TranscriptionResult(status="failed", error=error)
+            return TranscriptionResult(status="failed", provider="scribe", error=error)
 
     def process_batch(self, limit: int) -> WorkerResult:
         result = WorkerResult()
-        for episode in self.repository.get_episodes_pending_transcription(limit=limit):
+        for episode in self.repository.get_episodes_pending_transcription(
+            limit=limit, backend="scribe"
+        ):
             outcome = self.transcribe_single(episode)
             if outcome.is_complete:
                 result.processed += 1

--- a/src/workflow/workers/scribe_transcription.py
+++ b/src/workflow/workers/scribe_transcription.py
@@ -1,0 +1,131 @@
+"""Compatibility transcription worker backed by the shared Scribe service."""
+
+from __future__ import annotations
+
+import logging
+
+from src.config import Config
+from src.db.models import Episode
+from src.db.repository import PodcastRepositoryInterface
+from src.services.scribe import ScribeClient
+from src.workflow.workers.base import TranscriptionResult, WorkerInterface, WorkerResult
+
+logger = logging.getLogger(__name__)
+
+
+class ScribeTranscriptionWorker(WorkerInterface):
+    """Submit episode URLs to Scribe and copy completed text into podcast-rag."""
+
+    def __init__(
+        self,
+        config: Config,
+        repository: PodcastRepositoryInterface,
+        client: ScribeClient | None = None,
+    ):
+        self.config = config
+        self.repository = repository
+        self.client = client or ScribeClient(
+            base_url=config.SCRIBE_BASE_URL,
+            api_token=config.SCRIBE_API_TOKEN,
+            timeout=config.SCRIBE_REQUEST_TIMEOUT,
+        )
+
+    @property
+    def name(self) -> str:
+        return "Scribe Transcription"
+
+    def load_model(self) -> None:
+        """Scribe owns model warmup; podcast-rag has no local model to load."""
+        logger.info("Using remote Scribe transcription backend")
+
+    def unload_model(self) -> None:
+        """No-op because Scribe owns the model lifecycle."""
+
+    def is_model_loaded(self) -> bool:
+        """Return true because this worker has no local model lifecycle."""
+        return True
+
+    def get_pending_count(self) -> int:
+        return len(self.repository.get_episodes_pending_transcription(limit=1000))
+
+    def transcribe_single(self, episode: Episode) -> TranscriptionResult:
+        """Submit or poll one episode, updating podcast-rag compatibility state."""
+        try:
+            if not episode.enclosure_url:
+                raise ValueError(f"Episode {episode.id} has no enclosure_url")
+
+            if episode.transcript_status != "processing":
+                self.repository.mark_transcript_started(episode.id)
+
+            response = self.client.submit(
+                audio_url=episode.enclosure_url,
+                language=self.config.SCRIBE_LANGUAGE,
+                hint_guid=episode.guid,
+                hint_title=episode.title,
+            )
+
+            if response.status in {"queued", "processing"}:
+                self.repository.mark_transcript_remote_status(
+                    episode.id,
+                    provider="scribe",
+                    external_id=response.id,
+                    status=response.status,
+                )
+                return TranscriptionResult(
+                    status=response.status,
+                    external_id=response.id,
+                )
+
+            external_id = response.transcript_id or response.id
+            if response.status == "completed":
+                assert response.transcript is not None
+                self.repository.mark_transcript_complete(
+                    episode_id=episode.id,
+                    transcript_text=response.transcript,
+                    provider="scribe",
+                    external_id=external_id,
+                    model=response.model,
+                    language=response.language,
+                )
+                return TranscriptionResult(
+                    status="completed",
+                    transcript_text=response.transcript,
+                    external_id=external_id,
+                )
+
+            error = response.error or "Scribe transcription failed"
+            self.repository.mark_transcript_failed(
+                episode.id,
+                error,
+                provider="scribe",
+                external_id=external_id,
+            )
+            return TranscriptionResult(
+                status="failed",
+                external_id=external_id,
+                error=error,
+            )
+        except Exception as exc:
+            error = str(exc)
+            logger.exception("Scribe transcription failed for episode %s", episode.id)
+            self.repository.mark_transcript_failed(
+                episode.id,
+                error,
+                provider="scribe",
+                external_id=getattr(episode, "transcript_external_id", None),
+            )
+            return TranscriptionResult(status="failed", error=error)
+
+    def process_batch(self, limit: int) -> WorkerResult:
+        result = WorkerResult()
+        for episode in self.repository.get_episodes_pending_transcription(limit=limit):
+            outcome = self.transcribe_single(episode)
+            if outcome.is_complete:
+                result.processed += 1
+            elif outcome.is_waiting:
+                result.skipped += 1
+            else:
+                result.failed += 1
+                if outcome.error:
+                    result.errors.append(f"Episode {episode.id}: {outcome.error}")
+        return result

--- a/src/workflow/workers/transcription.py
+++ b/src/workflow/workers/transcription.py
@@ -15,7 +15,7 @@ import os
 from src.config import Config
 from src.db.models import Episode
 from src.db.repository import PodcastRepositoryInterface
-from src.workflow.workers.base import WorkerInterface, WorkerResult
+from src.workflow.workers.base import TranscriptionResult, WorkerInterface, WorkerResult
 
 logger = logging.getLogger(__name__)
 
@@ -204,7 +204,7 @@ class TranscriptionWorker(WorkerInterface):
         logger.info(f"Transcription complete for episode {episode.id}")
         return transcript_text
 
-    def transcribe_single(self, episode: Episode) -> str | None:
+    def transcribe_single(self, episode: Episode) -> TranscriptionResult:
         """Transcribe a single episode without releasing the model.
 
         Unlike process_batch, this method:
@@ -219,7 +219,7 @@ class TranscriptionWorker(WorkerInterface):
             episode: Episode to transcribe.
 
         Returns:
-            Transcript text if successful, None on failure.
+            Structured completed or failed result.
         """
         try:
             self.repository.mark_transcript_started(episode.id)
@@ -228,19 +228,22 @@ class TranscriptionWorker(WorkerInterface):
                 episode_id=episode.id,
                 transcript_text=transcript_text,
             )
-            return transcript_text
+            return TranscriptionResult(
+                status="completed",
+                transcript_text=transcript_text,
+            )
 
         except FileNotFoundError as e:
             error_msg = str(e)
             logger.exception(f"Episode {episode.id} transcription failed: file not found")
             self.repository.mark_transcript_failed(episode.id, error_msg)
-            return None
+            return TranscriptionResult(status="failed", error=error_msg)
 
         except Exception as e:
             error_msg = str(e)
             logger.exception(f"Episode {episode.id} transcription failed")
             self.repository.mark_transcript_failed(episode.id, error_msg)
-            return None
+            return TranscriptionResult(status="failed", error=error_msg)
 
     def process_batch(self, limit: int) -> WorkerResult:
         """Transcribe a batch of pending episodes.

--- a/src/workflow/workers/transcription.py
+++ b/src/workflow/workers/transcription.py
@@ -137,7 +137,9 @@ class TranscriptionWorker(WorkerInterface):
         Returns:
             Number of episodes waiting to be transcribed.
         """
-        episodes = self.repository.get_episodes_pending_transcription(limit=1000)
+        episodes = self.repository.get_episodes_pending_transcription(
+            limit=1000, backend="local"
+        )
         return len(episodes)
 
     def _transcribe_episode(self, episode: Episode) -> str:
@@ -258,7 +260,9 @@ class TranscriptionWorker(WorkerInterface):
 
         try:
             # Query episodes pending transcription, ordered by published_date DESC
-            episodes = self.repository.get_episodes_pending_transcription(limit=limit)
+            episodes = self.repository.get_episodes_pending_transcription(
+                limit=limit, backend="local"
+            )
 
             if not episodes:
                 logger.info("No episodes pending transcription")

--- a/tests/test_config_scribe.py
+++ b/tests/test_config_scribe.py
@@ -1,0 +1,50 @@
+"""Tests for validated Scribe configuration."""
+
+import pytest
+from pydantic import ValidationError
+
+from src.config import Config, ScribeSettings
+
+
+def test_scribe_settings_default_to_https() -> None:
+    settings = ScribeSettings()
+
+    assert str(settings.base_url).rstrip("/") == "https://scribe.vycari.ai"
+    assert settings.transcription_backend == "local"
+    assert settings.request_timeout == 30.0
+
+
+def test_scribe_settings_reject_http_without_explicit_opt_in() -> None:
+    with pytest.raises(ValidationError, match="SCRIBE_ALLOW_INSECURE_HTTP"):
+        ScribeSettings.model_validate({"base_url": "http://scribe:8000"})
+
+    settings = ScribeSettings.model_validate(
+        {
+            "base_url": "http://scribe:8000",
+            "allow_insecure_http": "true",
+        }
+    )
+    assert settings.allow_insecure_http is True
+
+
+@pytest.mark.parametrize("timeout", ["0", "-1", "inf", "nan"])
+def test_scribe_settings_require_positive_finite_timeout(timeout: str) -> None:
+    with pytest.raises(ValidationError):
+        ScribeSettings.model_validate({"request_timeout": timeout})
+
+
+def test_config_populates_normalized_scribe_attributes(monkeypatch) -> None:
+    monkeypatch.setattr("src.config.load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setenv("TRANSCRIPTION_BACKEND", "SCRIBE")
+    monkeypatch.setenv("SCRIBE_BASE_URL", "https://scribe.example.com/")
+    monkeypatch.setenv("SCRIBE_API_TOKEN", "token")
+    monkeypatch.setenv("SCRIBE_REQUEST_TIMEOUT", "12.5")
+    monkeypatch.setenv("SCRIBE_LANGUAGE", "")
+
+    config = Config()
+
+    assert config.TRANSCRIPTION_BACKEND == "scribe"
+    assert config.SCRIBE_BASE_URL == "https://scribe.example.com"
+    assert config.SCRIBE_API_TOKEN == "token"
+    assert config.SCRIBE_REQUEST_TIMEOUT == 12.5
+    assert config.SCRIBE_LANGUAGE is None

--- a/tests/test_export_transcripts_to_scribe.py
+++ b/tests/test_export_transcripts_to_scribe.py
@@ -2,13 +2,27 @@
 
 import hashlib
 import json
+from types import SimpleNamespace
 
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from scripts import export_transcripts_to_scribe as exporter
 from scripts.export_transcripts_to_scribe import export_transcripts
 from src.db.factory import create_repository
 
 
-def test_export_completed_transcripts_with_manifest(tmp_path) -> None:
+@pytest.fixture
+def repository(tmp_path):
+    """Yield an isolated repository and always close its connection pool."""
     repository = create_repository(f"sqlite:///{tmp_path / 'podcasts.db'}", create_tables=True)
+    try:
+        yield repository
+    finally:
+        repository.close()
+
+
+def test_export_completed_transcripts_with_manifest(repository, tmp_path) -> None:
     podcast = repository.create_podcast(feed_url="https://example.com/feed.xml", title="Podcast")
     first = repository.create_episode(
         podcast_id=podcast.id,
@@ -51,7 +65,6 @@ def test_export_completed_transcripts_with_manifest(tmp_path) -> None:
 
     output = tmp_path / "export.jsonl"
     manifest = export_transcripts(repository, output)
-    repository.close()
 
     rows = [json.loads(line) for line in output.read_text().splitlines()]
     assert len(rows) == 2
@@ -66,12 +79,63 @@ def test_export_completed_transcripts_with_manifest(tmp_path) -> None:
     assert output.with_suffix(".jsonl.manifest.json").exists()
 
 
-def test_dry_run_does_not_write_transcript_file(tmp_path) -> None:
-    repository = create_repository(f"sqlite:///{tmp_path / 'podcasts.db'}", create_tables=True)
+def test_empty_completed_transcript_exits_cleanly(
+    repository, tmp_path, monkeypatch, capsys
+) -> None:
+    podcast = repository.create_podcast(
+        feed_url="https://example.com/empty-feed.xml", title="Empty"
+    )
+    episode = repository.create_episode(
+        podcast_id=podcast.id,
+        guid="empty",
+        title="Empty transcript",
+        enclosure_url="https://example.com/empty.mp3",
+        enclosure_type="audio/mpeg",
+    )
+    repository.mark_transcript_complete(episode.id, transcript_text="")
+    output = tmp_path / "empty.jsonl"
+    config = SimpleNamespace(
+        DATABASE_URL="unused",
+        DB_POOL_SIZE=1,
+        DB_MAX_OVERFLOW=0,
+        DB_POOL_PRE_PING=False,
+        DB_ECHO=False,
+    )
+    monkeypatch.setattr(exporter, "Config", lambda: config)
+    monkeypatch.setattr(exporter, "create_repository", lambda **kwargs: repository)
+
+    assert exporter.main([str(output)]) == 0
+
+    rows = [json.loads(line) for line in output.read_text().splitlines()]
+    assert rows[0]["transcript_text"] == ""
+    manifest = json.loads(capsys.readouterr().out)
+    assert manifest["exported_rows"] == 1
+    assert manifest["skipped_missing_text"] == 0
+    assert manifest["conflicting_file_hashes"] == 0
+
+
+def test_dry_run_does_not_write_transcript_file(repository, tmp_path) -> None:
     output = tmp_path / "export.jsonl"
 
     manifest = export_transcripts(repository, output, dry_run=True)
-    repository.close()
 
     assert manifest["exported_rows"] == 0
     assert not output.exists()
+
+
+def test_export_logs_repository_failure_and_cleans_temp_file(
+    repository, tmp_path, monkeypatch, caplog
+) -> None:
+    output = tmp_path / "failed.jsonl"
+    monkeypatch.setattr(
+        repository,
+        "list_episodes",
+        lambda **kwargs: (_ for _ in ()).throw(SQLAlchemyError("database unavailable")),
+    )
+
+    with caplog.at_level("ERROR"), pytest.raises(SQLAlchemyError):
+        export_transcripts(repository, output)
+
+    assert not output.exists()
+    assert list(tmp_path.glob(".failed.jsonl.*")) == []
+    assert any(str(output) in record.message and record.exc_info for record in caplog.records)

--- a/tests/test_export_transcripts_to_scribe.py
+++ b/tests/test_export_transcripts_to_scribe.py
@@ -139,6 +139,22 @@ def test_main_logs_repository_initialization_failure(tmp_path, monkeypatch, capl
     )
 
 
+def test_main_does_not_mask_unexpected_initialization_failure(
+    tmp_path, monkeypatch, caplog
+) -> None:
+    output = tmp_path / "export.jsonl"
+    monkeypatch.setattr(
+        exporter,
+        "Config",
+        lambda: (_ for _ in ()).throw(TypeError("programming defect")),
+    )
+
+    with caplog.at_level("ERROR"), pytest.raises(TypeError, match="programming defect"):
+        exporter.main([str(output)])
+
+    assert not caplog.records
+
+
 def test_dry_run_does_not_write_transcript_file(repository, tmp_path) -> None:
     output = tmp_path / "export.jsonl"
 

--- a/tests/test_export_transcripts_to_scribe.py
+++ b/tests/test_export_transcripts_to_scribe.py
@@ -114,6 +114,31 @@ def test_empty_completed_transcript_exits_cleanly(
     assert manifest["conflicting_file_hashes"] == 0
 
 
+def test_main_logs_repository_initialization_failure(tmp_path, monkeypatch, caplog) -> None:
+    output = tmp_path / "export.jsonl"
+    config = SimpleNamespace(
+        DATABASE_URL="postgresql://invalid",
+        DB_POOL_SIZE=1,
+        DB_MAX_OVERFLOW=0,
+        DB_POOL_PRE_PING=False,
+        DB_ECHO=False,
+    )
+    failure = SQLAlchemyError("database unavailable")
+    monkeypatch.setattr(exporter, "Config", lambda: config)
+    monkeypatch.setattr(
+        exporter,
+        "create_repository",
+        lambda **kwargs: (_ for _ in ()).throw(failure),
+    )
+
+    with caplog.at_level("ERROR"), pytest.raises(SQLAlchemyError, match="database unavailable"):
+        exporter.main([str(output)])
+
+    assert any(
+        str(output) in record.message and record.exc_info for record in caplog.records
+    )
+
+
 def test_dry_run_does_not_write_transcript_file(repository, tmp_path) -> None:
     output = tmp_path / "export.jsonl"
 

--- a/tests/test_export_transcripts_to_scribe.py
+++ b/tests/test_export_transcripts_to_scribe.py
@@ -1,0 +1,77 @@
+"""Tests for the Scribe migration export."""
+
+import hashlib
+import json
+
+from scripts.export_transcripts_to_scribe import export_transcripts
+from src.db.factory import create_repository
+
+
+def test_export_completed_transcripts_with_manifest(tmp_path) -> None:
+    repository = create_repository(f"sqlite:///{tmp_path / 'podcasts.db'}", create_tables=True)
+    podcast = repository.create_podcast(feed_url="https://example.com/feed.xml", title="Podcast")
+    first = repository.create_episode(
+        podcast_id=podcast.id,
+        guid="one",
+        title="One",
+        enclosure_url="https://example.com/one.mp3",
+        enclosure_type="audio/mpeg",
+        duration_seconds=60,
+        file_hash="a" * 64,
+    )
+    repository.mark_transcript_complete(
+        first.id,
+        transcript_text="First transcript",
+        provider="local",
+        model="medium",
+        language="en",
+    )
+    second = repository.create_episode(
+        podcast_id=podcast.id,
+        guid="two",
+        title="Two",
+        enclosure_url="https://example.com/two.mp3",
+        enclosure_type="audio/mpeg",
+        file_hash="not-a-sha256",
+    )
+    repository.update_episode(second.id, transcript_status="completed")
+    third = repository.create_episode(
+        podcast_id=podcast.id,
+        guid="three",
+        title="Three",
+        enclosure_url="https://example.com/three.mp3",
+        enclosure_type="audio/mpeg",
+        file_hash="a" * 64,
+    )
+    repository.mark_transcript_complete(
+        third.id,
+        transcript_text="Conflicting transcript",
+        provider="local",
+    )
+
+    output = tmp_path / "export.jsonl"
+    manifest = export_transcripts(repository, output)
+    repository.close()
+
+    rows = [json.loads(line) for line in output.read_text().splitlines()]
+    assert len(rows) == 2
+    exported_first = next(row for row in rows if row["episode_id"] == first.id)
+    assert exported_first["transcript_text"] == "First transcript"
+    assert exported_first["transcript_sha256"] == hashlib.sha256(b"First transcript").hexdigest()
+    assert manifest["completed_rows"] == 3
+    assert manifest["exported_rows"] == 2
+    assert manifest["skipped_missing_text"] == 1
+    assert manifest["duplicate_file_hashes"] == 1
+    assert manifest["conflicting_file_hashes"] == 1
+    assert output.with_suffix(".jsonl.manifest.json").exists()
+
+
+def test_dry_run_does_not_write_transcript_file(tmp_path) -> None:
+    repository = create_repository(f"sqlite:///{tmp_path / 'podcasts.db'}", create_tables=True)
+    output = tmp_path / "export.jsonl"
+
+    manifest = export_transcripts(repository, output, dry_run=True)
+    repository.close()
+
+    assert manifest["exported_rows"] == 0
+    assert not output.exists()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,14 +1,14 @@
 """Tests for workflow orchestrator module."""
 
-import pytest
 import signal
-from datetime import datetime, UTC, timedelta
-from unittest.mock import Mock, patch, MagicMock
-from concurrent.futures import Future
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock, patch
 
-from src.workflow.orchestrator import PipelineOrchestrator, PipelineStats
+import pytest
+
 from src.workflow.config import PipelineConfig
-from src.workflow.workers.base import WorkerResult
+from src.workflow.orchestrator import PipelineOrchestrator, PipelineStats
+from src.workflow.workers.base import TranscriptionResult, WorkerResult
 
 
 class TestPipelineStats:
@@ -508,7 +508,9 @@ class TestPipelineOrchestratorIteration:
         mock_repository.get_next_for_transcription.return_value = mock_episode
 
         mock_worker = Mock()
-        mock_worker.transcribe_single.return_value = "/path/to/transcript.txt"
+        mock_worker.transcribe_single.return_value = TranscriptionResult(
+            status="completed", transcript_text="Transcript text"
+        )
         orchestrator._transcription_worker = mock_worker
         orchestrator._post_processor = Mock()
 
@@ -530,7 +532,9 @@ class TestPipelineOrchestratorIteration:
         mock_repository.increment_retry_count.return_value = 1
 
         mock_worker = Mock()
-        mock_worker.transcribe_single.return_value = None
+        mock_worker.transcribe_single.return_value = TranscriptionResult(
+            status="failed", error="transcription failed"
+        )
         orchestrator._transcription_worker = mock_worker
         orchestrator._running = True
 
@@ -551,14 +555,57 @@ class TestPipelineOrchestratorIteration:
         mock_repository.increment_retry_count.return_value = 4  # Exceeds max_retries=3
 
         mock_worker = Mock()
-        mock_worker.transcribe_single.return_value = None
+        mock_worker.transcribe_single.return_value = TranscriptionResult(
+            status="failed", error="transcription failed"
+        )
         orchestrator._transcription_worker = mock_worker
         orchestrator._running = True
 
-        result = orchestrator._pipeline_iteration()
+        orchestrator._pipeline_iteration()
 
         assert orchestrator._stats.transcription_permanent_failures == 1
         mock_repository.mark_permanently_failed.assert_called_once()
+
+    def test_pipeline_iteration_preserves_terminal_scribe_failure(
+        self, orchestrator, mock_repository
+    ):
+        """Terminal Scribe failures are not reset or locally retried."""
+        mock_episode = Mock(id="ep-1", title="Test Episode")
+        mock_repository.get_next_for_transcription.return_value = mock_episode
+        mock_worker = Mock()
+        mock_worker.transcribe_single.return_value = TranscriptionResult(
+            status="failed",
+            provider="scribe",
+            external_id="transcript-1",
+            error="download failed",
+            terminal=True,
+        )
+        orchestrator._transcription_worker = mock_worker
+        orchestrator._running = True
+
+        assert orchestrator._pipeline_iteration() is True
+        mock_repository.increment_retry_count.assert_not_called()
+        mock_repository.reset_episode_for_retry.assert_not_called()
+        mock_repository.mark_permanently_failed.assert_not_called()
+
+    def test_pipeline_iteration_backs_off_retryable_scribe_failure(
+        self, orchestrator, mock_repository
+    ):
+        """Transient Scribe failures reset once and yield to the idle delay."""
+        mock_episode = Mock(id="ep-1", title="Test Episode")
+        mock_repository.get_next_for_transcription.return_value = mock_episode
+        mock_repository.increment_retry_count.return_value = 1
+        mock_worker = Mock()
+        mock_worker.transcribe_single.return_value = TranscriptionResult(
+            status="retryable", provider="scribe", error="service unavailable"
+        )
+        orchestrator._transcription_worker = mock_worker
+        orchestrator._running = True
+
+        assert orchestrator._pipeline_iteration() is False
+        mock_repository.reset_episode_for_retry.assert_called_once_with(
+            "ep-1", "transcript"
+        )
 
 
 class TestPipelineOrchestratorPostProcess:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -380,6 +380,40 @@ class TestStatusUpdates:
         assert episode.transcript_status == "completed"
         assert episode.transcript_text == transcript_text
 
+    def test_remote_transcript_status_and_completion(self, repository, sample_podcast):
+        episode = repository.create_episode(
+            podcast_id=sample_podcast.id,
+            guid="remote-transcript",
+            title="Remote transcript",
+            enclosure_url="https://example.com/remote.mp3",
+            enclosure_type="audio/mpeg",
+        )
+
+        repository.mark_transcript_remote_status(
+            episode.id,
+            provider="scribe",
+            external_id="job-1",
+            status="queued",
+        )
+        processing = repository.get_episode(episode.id)
+        assert processing.transcript_status == "processing"
+        assert processing.transcript_provider == "scribe"
+        assert processing.transcript_external_id == "job-1"
+
+        repository.mark_transcript_complete(
+            episode.id,
+            transcript_text="Remote text",
+            provider="scribe",
+            external_id="transcript-1",
+            model="medium",
+            language="en",
+        )
+        completed = repository.get_episode(episode.id)
+        assert completed.transcript_text == "Remote text"
+        assert completed.transcript_external_id == "transcript-1"
+        assert completed.transcript_model == "medium"
+        assert completed.transcript_language == "en"
+
     def test_indexing_status_flow(self, repository, sample_podcast):
         """Test File Search indexing status transitions."""
         episode = repository.create_episode(

--- a/tests/test_scribe_client.py
+++ b/tests/test_scribe_client.py
@@ -1,0 +1,92 @@
+"""Tests for the podcast-rag Scribe API client."""
+
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from src.services.scribe import ScribeClient, ScribeClientError, ScribeTranscript
+
+
+def _client(response: Mock) -> tuple[ScribeClient, Mock]:
+    session = Mock()
+    session.headers = {}
+    session.post.return_value = response
+    return (
+        ScribeClient(
+            base_url="http://scribe:8000/",
+            api_token="secret",
+            timeout=12,
+            session=session,
+        ),
+        session,
+    )
+
+
+def test_submit_sends_idempotent_request() -> None:
+    response = Mock()
+    response.json.return_value = {"id": "job-1", "status": "queued"}
+    client, session = _client(response)
+
+    result = client.submit(
+        audio_url="https://example.com/episode.mp3",
+        language="en",
+        hint_guid="episode-guid",
+        hint_title="Episode title",
+    )
+
+    assert result == ScribeTranscript(id="job-1", status="queued")
+    session.post.assert_called_once_with(
+        "http://scribe:8000/v1/transcripts",
+        json={
+            "audio_url": "https://example.com/episode.mp3",
+            "language": "en",
+            "hint_guid": "episode-guid",
+            "hint_title": "Episode title",
+        },
+        timeout=12,
+    )
+
+
+def test_submit_parses_completed_response() -> None:
+    response = Mock()
+    response.json.return_value = {
+        "id": "job-1",
+        "transcript_id": "transcript-1",
+        "status": "completed",
+        "transcript": "Hello world",
+        "lang": "en",
+        "model": "medium",
+        "duration_seconds": 10.5,
+    }
+    client, _ = _client(response)
+
+    result = client.submit(audio_url="https://example.com/episode.mp3")
+
+    assert result.transcript_id == "transcript-1"
+    assert result.transcript == "Hello world"
+    assert result.language == "en"
+
+
+def test_completed_response_requires_transcript() -> None:
+    with pytest.raises(ScribeClientError, match="missing transcript"):
+        ScribeTranscript.from_payload({"id": "transcript-1", "status": "completed"})
+
+
+def test_request_error_is_sanitized_as_client_error() -> None:
+    session = Mock()
+    session.headers = {}
+    session.post.side_effect = requests.Timeout("timed out")
+    client = ScribeClient(
+        base_url="http://scribe:8000",
+        api_token="secret",
+        session=session,
+    )
+
+    with pytest.raises(ScribeClientError, match="Scribe request failed"):
+        client.submit(audio_url="https://example.com/episode.mp3")
+
+
+def test_token_is_required() -> None:
+    with pytest.raises(ValueError, match="SCRIBE_API_TOKEN"):
+        ScribeClient(base_url="http://scribe:8000", api_token="")

--- a/tests/test_scribe_client.py
+++ b/tests/test_scribe_client.py
@@ -1,6 +1,6 @@
 """Tests for the podcast-rag Scribe API client."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pytest
 import requests
@@ -11,10 +11,11 @@ from src.services.scribe import ScribeClient, ScribeClientError, ScribeTranscrip
 def _client(response: Mock) -> tuple[ScribeClient, Mock]:
     session = Mock()
     session.headers = {}
+    response.status_code = 200
     session.post.return_value = response
     return (
         ScribeClient(
-            base_url="http://scribe:8000/",
+            base_url="https://scribe.example.com/",
             api_token="secret",
             timeout=12,
             session=session,
@@ -37,7 +38,7 @@ def test_submit_sends_idempotent_request() -> None:
 
     assert result == ScribeTranscript(id="job-1", status="queued")
     session.post.assert_called_once_with(
-        "http://scribe:8000/v1/transcripts",
+        "https://scribe.example.com/v1/transcripts",
         json={
             "audio_url": "https://example.com/episode.mp3",
             "language": "en",
@@ -78,9 +79,10 @@ def test_request_error_is_sanitized_as_client_error() -> None:
     session.headers = {}
     session.post.side_effect = requests.Timeout("timed out")
     client = ScribeClient(
-        base_url="http://scribe:8000",
+        base_url="https://scribe.example.com",
         api_token="secret",
         session=session,
+        backoff_seconds=0,
     )
 
     with pytest.raises(ScribeClientError, match="Scribe request failed"):
@@ -89,4 +91,88 @@ def test_request_error_is_sanitized_as_client_error() -> None:
 
 def test_token_is_required() -> None:
     with pytest.raises(ValueError, match="SCRIBE_API_TOKEN"):
-        ScribeClient(base_url="http://scribe:8000", api_token="")
+        ScribeClient(base_url="https://scribe.example.com", api_token="")
+
+
+def test_submit_retries_transient_failures_with_same_body() -> None:
+    response = Mock(status_code=200)
+    response.json.return_value = {"id": "job-1", "status": "queued"}
+    session = Mock(headers={})
+    session.post.side_effect = [
+        requests.Timeout("first timeout"),
+        Mock(status_code=503),
+        response,
+    ]
+    sleep = Mock()
+    client = ScribeClient(
+        base_url="https://scribe.example.com",
+        api_token="secret",
+        timeout=12,
+        session=session,
+        backoff_seconds=0.25,
+        sleep=sleep,
+    )
+
+    result = client.submit(audio_url="https://example.com/episode.mp3")
+
+    assert result.status == "queued"
+    assert session.post.call_count == 3
+    assert [call.kwargs["json"] for call in session.post.call_args_list] == [
+        session.post.call_args_list[0].kwargs["json"]
+    ] * 3
+    assert sleep.call_args_list == [call(0.25), call(0.5)]
+
+
+def test_submit_logs_final_failure(caplog) -> None:
+    session = Mock(headers={})
+    session.post.side_effect = requests.Timeout("timed out")
+    client = ScribeClient(
+        base_url="https://scribe.example.com",
+        api_token="secret",
+        session=session,
+        backoff_seconds=0,
+    )
+
+    with caplog.at_level("ERROR"), pytest.raises(ScribeClientError) as exc_info:
+        client.submit(audio_url="https://example.com/episode.mp3")
+
+    assert exc_info.value.retryable is True
+    assert session.post.call_count == 3
+    assert any(
+        record.exc_info and "after 3 attempt(s)" in record.message for record in caplog.records
+    )
+
+
+def test_submit_does_not_retry_terminal_http_failure() -> None:
+    response = Mock(status_code=400)
+    response.raise_for_status.side_effect = requests.HTTPError("bad request", response=response)
+    session = Mock(headers={})
+    session.post.return_value = response
+    client = ScribeClient(
+        base_url="https://scribe.example.com",
+        api_token="secret",
+        session=session,
+    )
+
+    with pytest.raises(ScribeClientError) as exc_info:
+        client.submit(audio_url="https://example.com/episode.mp3")
+
+    assert exc_info.value.retryable is False
+    session.post.assert_called_once()
+
+
+def test_invalid_request_and_response_fields_raise_client_error() -> None:
+    response = Mock(status_code=200)
+    response.json.return_value = {
+        "id": "job-1",
+        "status": "queued",
+        "lang": 123,
+    }
+    client, session = _client(response)
+
+    with pytest.raises(ScribeClientError, match="Invalid Scribe request"):
+        client.submit(audio_url=object())  # type: ignore[arg-type]
+    session.post.assert_not_called()
+
+    with pytest.raises(ScribeClientError, match="Invalid Scribe response"):
+        client.submit(audio_url="https://example.com/episode.mp3")

--- a/tests/test_scribe_transcription.py
+++ b/tests/test_scribe_transcription.py
@@ -1,0 +1,100 @@
+"""Tests for the Scribe-backed compatibility transcription worker."""
+
+from unittest.mock import Mock
+
+from src.services.scribe import ScribeTranscript
+from src.workflow.workers.scribe_transcription import ScribeTranscriptionWorker
+
+
+def _worker(response: ScribeTranscript):
+    config = Mock()
+    config.SCRIBE_LANGUAGE = "en"
+    repository = Mock()
+    client = Mock()
+    client.submit.return_value = response
+    worker = ScribeTranscriptionWorker(config, repository, client=client)
+
+    episode = Mock()
+    episode.id = "episode-1"
+    episode.guid = "guid-1"
+    episode.title = "Episode 1"
+    episode.enclosure_url = "https://example.com/episode.mp3"
+    episode.transcript_status = "pending"
+    episode.transcript_retry_count = 0
+    episode.transcript_external_id = None
+    return worker, repository, client, episode
+
+
+def test_queued_response_records_remote_handle() -> None:
+    worker, repository, _, episode = _worker(ScribeTranscript(id="job-1", status="queued"))
+
+    result = worker.transcribe_single(episode)
+
+    assert result.status == "queued"
+    repository.mark_transcript_started.assert_called_once_with("episode-1")
+    repository.mark_transcript_remote_status.assert_called_once_with(
+        "episode-1",
+        provider="scribe",
+        external_id="job-1",
+        status="queued",
+    )
+    repository.mark_transcript_complete.assert_not_called()
+    repository.mark_transcript_failed.assert_not_called()
+
+
+def test_processing_response_does_not_restart_status() -> None:
+    worker, repository, _, episode = _worker(ScribeTranscript(id="job-1", status="processing"))
+    episode.transcript_status = "processing"
+
+    result = worker.transcribe_single(episode)
+
+    assert result.status == "processing"
+    repository.mark_transcript_started.assert_not_called()
+
+
+def test_completed_response_keeps_compatibility_copy() -> None:
+    worker, repository, _, episode = _worker(
+        ScribeTranscript(
+            id="job-1",
+            transcript_id="transcript-1",
+            status="completed",
+            transcript="Transcript text",
+            language="en",
+            model="medium",
+        )
+    )
+
+    result = worker.transcribe_single(episode)
+
+    assert result.is_complete
+    assert result.external_id == "transcript-1"
+    repository.mark_transcript_complete.assert_called_once_with(
+        episode_id="episode-1",
+        transcript_text="Transcript text",
+        provider="scribe",
+        external_id="transcript-1",
+        model="medium",
+        language="en",
+    )
+
+
+def test_failed_response_is_terminal_for_this_attempt() -> None:
+    worker, repository, _, episode = _worker(
+        ScribeTranscript(
+            id="job-1",
+            transcript_id="transcript-1",
+            status="failed",
+            error="download failed",
+        )
+    )
+
+    result = worker.transcribe_single(episode)
+
+    assert result.status == "failed"
+    assert result.error == "download failed"
+    repository.mark_transcript_failed.assert_called_once_with(
+        "episode-1",
+        "download failed",
+        provider="scribe",
+        external_id="transcript-1",
+    )

--- a/tests/test_scribe_transcription.py
+++ b/tests/test_scribe_transcription.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import Mock
 
-from src.services.scribe import ScribeTranscript
+from src.services.scribe import ScribeClientError, ScribeTranscript
 from src.workflow.workers.scribe_transcription import ScribeTranscriptionWorker
 
 
@@ -78,6 +78,28 @@ def test_completed_response_keeps_compatibility_copy() -> None:
     )
 
 
+def test_completed_response_falls_back_to_job_id() -> None:
+    worker, repository, _, episode = _worker(
+        ScribeTranscript(
+            id="job-1",
+            status="completed",
+            transcript="Transcript text",
+        )
+    )
+
+    result = worker.transcribe_single(episode)
+
+    assert result.external_id == "job-1"
+    repository.mark_transcript_complete.assert_called_once_with(
+        episode_id="episode-1",
+        transcript_text="Transcript text",
+        provider="scribe",
+        external_id="job-1",
+        model=None,
+        language=None,
+    )
+
+
 def test_failed_response_is_terminal_for_this_attempt() -> None:
     worker, repository, _, episode = _worker(
         ScribeTranscript(
@@ -91,10 +113,33 @@ def test_failed_response_is_terminal_for_this_attempt() -> None:
     result = worker.transcribe_single(episode)
 
     assert result.status == "failed"
+    assert result.is_terminal
+    assert result.provider == "scribe"
+    assert result.external_id == "transcript-1"
     assert result.error == "download failed"
     repository.mark_transcript_failed.assert_called_once_with(
         "episode-1",
         "download failed",
         provider="scribe",
         external_id="transcript-1",
+    )
+
+
+def test_request_failure_is_retryable_with_remote_identity() -> None:
+    worker, repository, client, episode = _worker(ScribeTranscript(id="unused", status="queued"))
+    episode.transcript_status = "processing"
+    episode.transcript_external_id = "job-1"
+    client.submit.side_effect = ScribeClientError("service unavailable", retryable=True)
+
+    result = worker.transcribe_single(episode)
+
+    assert result.status == "retryable"
+    assert result.should_backoff
+    assert result.provider == "scribe"
+    assert result.external_id == "job-1"
+    repository.mark_transcript_failed.assert_called_once_with(
+        "episode-1",
+        "service unavailable",
+        provider="scribe",
+        external_id="job-1",
     )

--- a/tests/test_scribe_transcription.py
+++ b/tests/test_scribe_transcription.py
@@ -137,9 +137,28 @@ def test_request_failure_is_retryable_with_remote_identity() -> None:
     assert result.should_backoff
     assert result.provider == "scribe"
     assert result.external_id == "job-1"
-    repository.mark_transcript_failed.assert_called_once_with(
+    repository.record_transcript_error.assert_called_once_with(
         "episode-1",
         "service unavailable",
         provider="scribe",
         external_id="job-1",
     )
+    repository.mark_transcript_failed.assert_not_called()
+
+
+def test_non_retryable_request_failure_is_terminal() -> None:
+    worker, repository, client, episode = _worker(ScribeTranscript(id="unused", status="queued"))
+    client.submit.side_effect = ScribeClientError("bad request", retryable=False)
+
+    result = worker.transcribe_single(episode)
+
+    assert result.status == "failed"
+    assert result.is_terminal
+    assert result.provider == "scribe"
+    repository.mark_transcript_failed.assert_called_once_with(
+        "episode-1",
+        "bad request",
+        provider="scribe",
+        external_id=None,
+    )
+    repository.record_transcript_error.assert_not_called()

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -858,7 +858,9 @@ class TestTranscriptionWorker:
         count = transcription_worker.get_pending_count()
 
         assert count == 2
-        mock_repository.get_episodes_pending_transcription.assert_called_with(limit=1000)
+        mock_repository.get_episodes_pending_transcription.assert_called_with(
+            limit=1000, backend="local"
+        )
 
     def test_transcribe_episode_no_file_path(self, transcription_worker):
         """Test transcribing episode without file path."""

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -915,7 +915,8 @@ class TestTranscriptionWorker:
 
         result = transcription_worker.transcribe_single(episode)
 
-        assert result == "Transcribed text"
+        assert result.status == "completed"
+        assert result.transcript_text == "Transcribed text"
         mock_repository.mark_transcript_started.assert_called_with("ep-1")
         mock_repository.mark_transcript_complete.assert_called()
 
@@ -928,7 +929,7 @@ class TestTranscriptionWorker:
 
         result = transcription_worker.transcribe_single(episode)
 
-        assert result is None
+        assert result.status == "failed"
         mock_repository.mark_transcript_failed.assert_called()
 
     def test_process_batch_no_episodes(self, transcription_worker, mock_repository):

--- a/tests/test_workers_db_storage.py
+++ b/tests/test_workers_db_storage.py
@@ -112,8 +112,9 @@ class TestTranscriptionWorkerDatabaseStorage:
         # Transcribe
         result = worker.transcribe_single(sample_episode_with_audio)
 
-        # Verify result is text
-        assert result == "Full transcript text."
+        # Verify the structured result carries the text
+        assert result.status == "completed"
+        assert result.transcript_text == "Full transcript text."
 
         # Verify database was updated
         episode = repository.get_episode(sample_episode_with_audio.id)
@@ -249,7 +250,8 @@ class TestTranscriptionWorkerDatabaseStorage:
         result = worker.transcribe_single(sample_episode_with_audio)
 
         # Verify Unicode preserved
-        assert "émojis 🎙️" in result
+        assert result.transcript_text is not None
+        assert "émojis 🎙️" in result.transcript_text
 
         episode = repository.get_episode(sample_episode_with_audio.id)
         assert "émojis 🎙️" in episode.transcript_text

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -662,6 +662,34 @@ class TestRetryMethods:
         assert next_ep is not None
         assert next_ep.id == episode.id
 
+    def test_get_next_for_transcription_includes_scribe_processing(
+        self, repository, sample_podcast
+    ):
+        episode = repository.create_episode(
+            podcast_id=sample_podcast.id,
+            guid="scribe-processing",
+            title="Scribe processing",
+            enclosure_url="https://example.com/scribe.mp3",
+            enclosure_type="audio/mpeg",
+        )
+        repository.mark_download_complete(
+            episode_id=episode.id,
+            local_path="/tmp/scribe.mp3",
+            file_size=1000,
+            file_hash="abc123",
+        )
+        repository.mark_transcript_remote_status(
+            episode.id,
+            provider="scribe",
+            external_id="job-1",
+            status="processing",
+        )
+
+        next_ep = repository.get_next_for_transcription()
+
+        assert next_ep is not None
+        assert next_ep.id == episode.id
+
 
 class TestTranscriptionWorkerPipeline:
     """Tests for TranscriptionWorker pipeline mode methods."""

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -684,6 +684,16 @@ class TestRetryMethods:
             external_id="job-1",
             status="processing",
         )
+        repository.record_transcript_error(
+            episode.id,
+            "temporary outage",
+            provider="scribe",
+            external_id="job-1",
+        )
+
+        retryable = repository.get_episode(episode.id)
+        assert retryable.transcript_status == "processing"
+        assert retryable.transcript_error == "temporary outage"
 
         assert repository.get_episodes_pending_transcription(backend="local") == []
         scribe_pending = repository.get_episodes_pending_transcription(backend="scribe")
@@ -697,6 +707,14 @@ class TestRetryMethods:
 
         assert next_ep is not None
         assert next_ep.id == episode.id
+
+        repository.reset_episode_for_retry(episode.id, "transcript")
+
+        assert repository.get_episodes_pending_transcription(backend="local") == []
+        scribe_pending = repository.get_episodes_pending_transcription(backend="scribe")
+        assert [pending.id for pending in scribe_pending] == [episode.id]
+        assert repository.get_next_for_transcription(backend="local") is None
+        assert repository.get_next_for_transcription(backend="scribe").id == episode.id
 
 
 class TestTranscriptionWorkerPipeline:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -685,7 +685,15 @@ class TestRetryMethods:
             status="processing",
         )
 
-        next_ep = repository.get_next_for_transcription()
+        assert repository.get_episodes_pending_transcription(backend="local") == []
+        scribe_pending = repository.get_episodes_pending_transcription(backend="scribe")
+        assert [pending.id for pending in scribe_pending] == [episode.id]
+
+        next_ep = repository.get_next_for_transcription(backend="local")
+
+        assert next_ep is None
+
+        next_ep = repository.get_next_for_transcription(backend="scribe")
 
         assert next_ep is not None
         assert next_ep.id == episode.id


### PR DESCRIPTION
## Summary

- add an opt-in Scribe transcription backend while keeping `local` as the default
- submit enclosure URLs idempotently, poll queued work on later pipeline ticks, and copy completed text back into PostgreSQL for compatibility
- persist transcript provider, external ID, model, and language through a reversible Alembic migration
- export completed transcripts as owner-only JSONL with hashes and a verification manifest
- add a canary-first, no-downtime migration runbook that keeps Scribe available to Pepper

## Dependency

Depends on Vycari/scribe#7. Merge and deploy that PR before running the seed or enabling `TRANSCRIPTION_BACKEND=scribe`.

The application client remains compatible with the pre-change Scribe response because `transcript_id` is optional and falls back to `id`.

## Pepper compatibility

Scribe is shared with the live Pepper podcast collector. This PR does not request replacement of cached failures; terminal failures remain immutable across both consumers.

## Validation

- migration-focused regression suite: 251 passed
- worker database-storage suite: 17 passed
- targeted Ruff check and format check passed for all new migration files
- Alembic upgrade and downgrade validated

The repository-wide 1,194-test run reproduced the existing Starlette/FastAPI `TestClient` hang on its first route test; no migration test failed. CodeRabbit will review this PR through the GitHub integration.

## Rollout

1. Deploy Vycari/scribe#7.
2. Inventory, back up, export, and seed a 100-row canary.
3. Observe at least one Pepper collector interval.
4. Complete and verify the idempotent full seed.
5. Enable the Scribe backend for podcast-rag and verify one cache hit plus one fresh episode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Scribe as a selectable transcription service with configurable language, timeout, and connection settings.
  * Added remote job tracking and transcript metadata.
  * Added validated JSONL transcript export with manifests and dry-run support.
  * Added automatic retries for temporary service failures.
* **Bug Fixes**
  * Improved handling of pending jobs and permanent versus retryable failures.
  * Secure HTTPS is now the default, with explicit opt-in for insecure HTTP.
* **Documentation**
  * Added configuration guidance and a reversible Scribe migration runbook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->