### PR TITLE
feat(mcp): migrate server to SDK v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ encoding = [
     "faster-whisper>=1.0.0",
     "APScheduler>=3.10.0",
     "eyed3>=0.9.0",
-    "mcp>=1.27.2",
+    "mcp>=2.1.1,<3",
     "tqdm>=4.70.0",
     # NVIDIA cuDNN libraries for GPU support (required for faster-whisper on CUDA)
     "nvidia-cublas-cu12; sys_platform == 'linux'",

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 
-from mcp.server import FastMCP as MCP
+from mcp.server import MCPServer
 
 from src.argparse_shared import add_log_level_argument, get_base_parser
 from src.config import Config
@@ -45,8 +45,8 @@ def main():
 
     # Initialize the MCP server
     logging.debug("Creating MCP server instance...")
-    mcp = MCP(port=5002)
-    logging.info("MCP server instance created on port 5002")
+    mcp = MCPServer("Podcast RAG")
+    logging.info("MCP server instance created")
 
     @mcp.tool()
     def get_rag_context(query: str):
@@ -182,7 +182,7 @@ def main():
     try:
         # Run the server with SSE transport
         logging.debug("Calling mcp.run() with sse transport...")
-        mcp.run(transport='sse')
+        mcp.run(transport="sse", port=5002)
         logging.debug("mcp.run() completed")
     except KeyboardInterrupt:
         logging.info("MCP server stopped by user")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -8,7 +8,7 @@ import logging
 class TestMCPServerMain:
     """Tests for MCP server main function."""
 
-    @patch("src.mcp_server.MCP")
+    @patch("src.mcp_server.MCPServer")
     @patch("src.mcp_server.Config")
     @patch("src.mcp_server.GeminiSearchManager")
     def test_main_initializes_server(self, mock_search_manager, mock_config_class, mock_mcp_class):
@@ -18,15 +18,16 @@ class TestMCPServerMain:
 
         mock_mcp = Mock()
         mock_mcp_class.return_value = mock_mcp
+        mock_mcp.run.side_effect = KeyboardInterrupt
 
         with patch("sys.argv", ["mcp_server", "-l", "INFO"]):
-            with patch.object(mock_mcp, "run", side_effect=KeyboardInterrupt):
-                from src.mcp_server import main
-                main()
+            from src.mcp_server import main
+            main()
 
-        mock_mcp_class.assert_called_once_with(port=5002)
+        mock_mcp_class.assert_called_once_with("Podcast RAG")
+        mock_mcp.run.assert_called_once_with(transport="sse", port=5002)
 
-    @patch("src.mcp_server.MCP")
+    @patch("src.mcp_server.MCPServer")
     @patch("src.mcp_server.Config")
     def test_main_with_env_file(self, mock_config_class, mock_mcp_class):
         """Test main with custom env file."""
@@ -158,9 +159,20 @@ class TestMCPTools:
 class TestMCPServerIntegration:
     """Integration-style tests for MCP server."""
 
+    def test_main_registers_tools_with_mcp_v2(self):
+        """Test that the real MCP v2 server accepts all tool registrations."""
+        from src.mcp_server import MCPServer, main
+
+        with patch("src.mcp_server.Config"):
+            with patch.object(MCPServer, "run", side_effect=KeyboardInterrupt) as mock_run:
+                with patch("sys.argv", ["mcp_server", "-l", "INFO"]):
+                    main()
+
+        mock_run.assert_called_once_with(transport="sse", port=5002)
+
     def test_module_imports_correctly(self):
         """Test that the module can be imported."""
-        with patch("src.mcp_server.MCP"):
+        with patch("src.mcp_server.MCPServer"):
             with patch("src.mcp_server.Config"):
                 import src.mcp_server
                 assert hasattr(src.mcp_server, "main")
@@ -176,7 +188,7 @@ class TestMCPServerIntegration:
 class TestMCPServerMainAdvanced:
     """Advanced tests for MCP server main function."""
 
-    @patch("src.mcp_server.MCP")
+    @patch("src.mcp_server.MCPServer")
     @patch("src.mcp_server.Config")
     def test_main_config_failure(self, mock_config_class, mock_mcp_class):
         """Test main handles config initialization failure."""
@@ -189,7 +201,7 @@ class TestMCPServerMainAdvanced:
 
             assert exc_info.value.code == 1
 
-    @patch("src.mcp_server.MCP")
+    @patch("src.mcp_server.MCPServer")
     @patch("src.mcp_server.Config")
     def test_main_server_error(self, mock_config_class, mock_mcp_class):
         """Test main handles server runtime error."""

--- a/uv.lock
+++ b/uv.lock
@@ -967,6 +967,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1011,12 +1024,29 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -1231,15 +1261,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1249,9 +1279,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
 ]
 
 [[package]]
@@ -1824,7 +1867,7 @@ dev = [
     { name = "faster-whisper", specifier = ">=1.0.0" },
     { name = "google-adk", specifier = ">=2.6.2" },
     { name = "itsdangerous", specifier = ">=2.1.0" },
-    { name = "mcp", specifier = ">=1.27.2" },
+    { name = "mcp", specifier = ">=2.1.1,<3" },
     { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
     { name = "poethepoet", specifier = ">=0.48.0" },
@@ -1841,7 +1884,7 @@ encoding = [
     { name = "apscheduler", specifier = ">=3.10.0" },
     { name = "eyed3", specifier = ">=0.9.0" },
     { name = "faster-whisper", specifier = ">=1.0.0" },
-    { name = "mcp", specifier = ">=1.27.2" },
+    { name = "mcp", specifier = ">=2.1.1,<3" },
     { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
     { name = "tqdm", specifier = ">=4.70.0" },
@@ -2111,20 +2154,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -2751,6 +2780,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
     { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- upgrade the supported MCP SDK range to `>=2.1.1,<3` and refresh the lockfile
- replace the removed `FastMCP` API with `MCPServer`
- move the SSE port configuration from the server constructor to `run()` as required by MCP v2
- update mocks and add a regression test that registers the real tools with MCP v2

This supersedes Dependabot PR #196, which updates the lockfile without applying the required v2 API migration.

## Validation

- `uv lock --check`
- `pytest tests/test_mcp_server.py -q`: 24 passed
- `pytest -q` on Python 3.11: 1207 passed, 8 skipped
- CodeRabbit review: 0 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved podcast server compatibility with the latest supported MCP protocol.
  - Standardized server startup for SSE connections on port 5002.

- **Bug Fixes**
  - Resolved server initialization and transport configuration issues that could prevent MCP tools from registering or connecting correctly.

- **Tests**
  - Expanded coverage for server startup, tool registration, SSE configuration, imports, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->